### PR TITLE
Fix compilation on MinGW.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,7 +418,7 @@ ENDIF ( )
 #####
 ############################################################################
 
-IF (NOT WIN32)
+IF (NOT WIN32 OR MINGW)
 
   ADD_EXECUTABLE(genheader_pmmg ${PROJECT_SOURCE_DIR}/scripts/genheader.c)
 
@@ -557,7 +557,7 @@ ENDIF ( )
 #####
 ############################################################################
 
-IF (NOT WIN32)
+IF (NOT WIN32 OR MINGW)
 
   ADD_CUSTOM_TARGET(GenerateGitHash
     COMMAND ./git_log_pmmg.sh ${PROJECT_SOURCE_DIR} ${PMMG_BINARY_DIR}


### PR DESCRIPTION
This fix is necessary for successfully compiling ParMmg on Windows with MinGW toolchain, cf. FreeFEM Jenkins [log](https://ci.inria.fr/freefem-dev/view/Windows/job/FreeFEM-sources-windows7-job5/161/consoleText).