### PR TITLE
Feature/load balancing

### DIFF
--- a/src/API_functions_pmmg.c
+++ b/src/API_functions_pmmg.c
@@ -144,6 +144,7 @@ void PMMG_Init_parameters(PMMG_pParMesh parmesh,MPI_Comm comm) {
   parmesh->info.root               = PMMG_NUL;
 
   parmesh->ddebug                  = PMMG_NUL;
+  parmesh->iter                    = PMMG_NUL;
   parmesh->niter                   = PMMG_NITER;
   parmesh->info.fem                = MMG5_FEM;
   parmesh->info.repartitioning     = PMMG_REDISTRIBUTION_mode;

--- a/src/API_functions_pmmg.c
+++ b/src/API_functions_pmmg.c
@@ -140,20 +140,21 @@ void PMMG_Init_parameters(PMMG_pParMesh parmesh,MPI_Comm comm) {
 
   memset(&parmesh->info,0, sizeof(PMMG_Info));
 
-  parmesh->info.mem    = PMMG_UNSET; /* [n/-1]   ,Set memory size to n Mbytes/keep the default value */
-  parmesh->info.root   = PMMG_NUL;
+  parmesh->info.mem                = PMMG_UNSET; /* [n/-1]   ,Set memory size to n Mbytes/keep the default value */
+  parmesh->info.root               = PMMG_NUL;
 
-  parmesh->ddebug      = PMMG_NUL;
-  parmesh->niter       = PMMG_NITER;
-  parmesh->info.fem    = MMG5_FEM;
-  parmesh->info.repartitioning = PMMG_REDISTRIBUTION_mode;
-  parmesh->info.ifc_layers = PMMG_MVIFCS_NLAYERS;
-  parmesh->info.grps_ratio = PMMG_GRPS_RATIO;
+  parmesh->ddebug                  = PMMG_NUL;
+  parmesh->niter                   = PMMG_NITER;
+  parmesh->info.fem                = MMG5_FEM;
+  parmesh->info.repartitioning     = PMMG_REDISTRIBUTION_mode;
+  parmesh->info.ifc_layers         = PMMG_MVIFCS_NLAYERS;
+  parmesh->info.grps_ratio         = PMMG_GRPS_RATIO;
+  parmesh->info.nobalancing        = MMG5_OFF;
   parmesh->info.loadbalancing_mode = PMMG_LOADBALANCING_metis;
-  parmesh->info.contiguous_mode = PMMG_CONTIG_DEF;
-  parmesh->info.target_mesh_size =  PMMG_REMESHER_TARGET_MESH_SIZE;
-  parmesh->info.metis_ratio =  PMMG_RATIO_MMG_METIS;
-  parmesh->info.API_mode    =  PMMG_APIDISTRIB_faces;
+  parmesh->info.contiguous_mode    = PMMG_CONTIG_DEF;
+  parmesh->info.target_mesh_size   = PMMG_REMESHER_TARGET_MESH_SIZE;
+  parmesh->info.metis_ratio        = PMMG_RATIO_MMG_METIS;
+  parmesh->info.API_mode           = PMMG_APIDISTRIB_faces;
 
   for ( k=0; k<parmesh->ngrp; ++k ) {
     mesh = parmesh->listgrp[k].mesh;
@@ -321,6 +322,9 @@ int PMMG_Set_iparameter(PMMG_pParMesh parmesh, int iparam,int val) {
     break;
   case PMMG_IPARAM_meshSize :
     parmesh->info.target_mesh_size = val;
+    break;
+  case PMMG_IPARAM_nobalancing :
+    parmesh->info.nobalancing = val;
     break;
   case PMMG_IPARAM_metisRatio :
     parmesh->info.metis_ratio = val;

--- a/src/grpsplit_pmmg.c
+++ b/src/grpsplit_pmmg.c
@@ -1487,6 +1487,7 @@ int PMMG_splitPart_grps( PMMG_pParMesh parmesh,int target,int fitMesh,int redist
 
   if ( !meshOld ) goto end;
 
+  /* Count how many groups to split into */
   if( (redistrMode == PMMG_REDISTRIBUTION_ifc_displacement) &&
       (target == PMMG_GRPSPL_DISTR_TARGET) ) {
     /* Set to a value higher than 1 just to continue until the true
@@ -1578,7 +1579,10 @@ int PMMG_splitPart_grps( PMMG_pParMesh parmesh,int target,int fitMesh,int redist
   PMMG_CALLOC(parmesh,part,meshOld->ne,idx_t,"metis buffer ", return 0);
   meshOld_ne = meshOld->ne;
 
-
+  /* Get interfaces layers or call metis. Use interface displacement if:
+   * - This is the required method, and
+   * - you are before group distribution or there are not too many groups.
+   */
   if( (redistrMode == PMMG_REDISTRIBUTION_ifc_displacement) &&
       ((target == PMMG_GRPSPL_DISTR_TARGET) ||
        ((target == PMMG_GRPSPL_MMG_TARGET) &&
@@ -1602,7 +1606,7 @@ int PMMG_splitPart_grps( PMMG_pParMesh parmesh,int target,int fitMesh,int redist
     }
     
     /* If this is the first split of the input mesh, and interface displacement
-     * will beb performed, check that the groups are contiguous. */
+     * will be performed, check that the groups are contiguous. */
     if( parmesh->info.repartitioning == PMMG_REDISTRIBUTION_ifc_displacement )
       if( !PMMG_fix_contiguity_split( parmesh,ngrp,part ) ) return 0;
   }

--- a/src/libparmmg.h
+++ b/src/libparmmg.h
@@ -73,6 +73,7 @@ enum PMMG_Param {
   PMMG_IPARAM_anisosize,         /*!< [1/0], Turn on/off anisotropic metric creation when no metric is provided */
   PMMG_IPARAM_octree,            /*!< [n], Specify the max number of points per octree cell (DELAUNAY) */
   PMMG_IPARAM_meshSize,          /*!< [n], Target mesh size of Mmg (advanced use) */
+  PMMG_IPARAM_nobalancing,       /*!< [1/0], Deactivate load balancing of the output mesh */
   PMMG_IPARAM_metisRatio,        /*!< [n], wanted ratio # mesh / # metis super nodes (advanced use) */
   PMMG_IPARAM_ifcLayers,         /*!< [n], Number of layers of interface displacement */
   PMMG_DPARAM_groupsRatio,       /*!< [val], Allowed imbalance between current and desired groups size */

--- a/src/libparmmg1.c
+++ b/src/libparmmg1.c
@@ -460,7 +460,7 @@ int PMMG_parmmglib1( PMMG_pParMesh parmesh )
   MMG5_pSol  met;
   size_t     oldMemMax,available;
   mytime     ctim[TIMEMAX];
-  int        it,ier,ier_end,ieresult,i,k,*facesData,*permNodGlob;
+  int        ier,ier_end,ieresult,i,k,*facesData,*permNodGlob;
   int8_t     tim,warnScotch;
   char       stim[32];
 
@@ -513,10 +513,10 @@ int PMMG_parmmglib1( PMMG_pParMesh parmesh )
 
   /** Mesh adaptation */
   warnScotch = 0;
-  for ( it = 0; it < parmesh->niter; ++it ) {
+  for ( parmesh->iter = 0; parmesh->iter < parmesh->niter; parmesh->iter++ ) {
     if ( parmesh->info.imprim > PMMG_VERB_STEPS ) {
       tim = 1;
-      if ( it > 0 ) {
+      if ( parmesh->iter > 0 ) {
         chrono(OFF,&(ctim[tim]));
       }
       if ( parmesh->info.imprim > PMMG_VERB_ITWAVES ) {
@@ -525,7 +525,7 @@ int PMMG_parmmglib1( PMMG_pParMesh parmesh )
 
       printim(ctim[tim].gdif,stim);
       chrono(ON,&(ctim[tim]));
-      fprintf(stdout,"\r       adaptation: iter %d   cumul. timer %s",it+1,stim);fflush(stdout);
+      fprintf(stdout,"\r       adaptation: iter %d   cumul. timer %s",parmesh->iter+1,stim);fflush(stdout);
     }
 
     /** Update old groups for metrics interpolation */
@@ -701,7 +701,7 @@ int PMMG_parmmglib1( PMMG_pParMesh parmesh )
       chrono(ON,&(ctim[tim]));
     }
 
-    if( (it == parmesh->niter-1) && !parmesh->info.nobalancing ) {
+    if( (parmesh->iter == parmesh->niter-1) && !parmesh->info.nobalancing ) {
       parmesh->info.repartitioning = PMMG_REDISTRIBUTION_graph_balancing;
     }
     ier = PMMG_loadBalancing(parmesh);

--- a/src/libparmmg1.c
+++ b/src/libparmmg1.c
@@ -701,6 +701,9 @@ int PMMG_parmmglib1( PMMG_pParMesh parmesh )
       chrono(ON,&(ctim[tim]));
     }
 
+    if( (it == parmesh->niter-1) && !parmesh->info.nobalancing ) {
+      parmesh->info.repartitioning = PMMG_REDISTRIBUTION_graph_balancing;
+    }
     ier = PMMG_loadBalancing(parmesh);
 
     MPI_Allreduce( &ier, &ieresult, 1, MPI_INT, MPI_MIN, parmesh->comm );

--- a/src/libparmmg1.c
+++ b/src/libparmmg1.c
@@ -634,7 +634,7 @@ int PMMG_parmmglib1( PMMG_pParMesh parmesh )
           fprintf(stderr,"\n  ## MMG remeshing problem. Exit program.\n");
         }
 
-        if ( it < parmesh->niter-1 && (!inputMet) ) {
+        if ( parmesh->iter < parmesh->niter-1 && (!inputMet) ) {
           /* Delete the metrec computed by Mmg except at last iter */
           PMMG_DEL_MEM(mesh,met->m,double,"internal metric");
         }

--- a/src/libparmmg1.c
+++ b/src/libparmmg1.c
@@ -702,9 +702,24 @@ int PMMG_parmmglib1( PMMG_pParMesh parmesh )
     }
 
     if( (parmesh->iter == parmesh->niter-1) && !parmesh->info.nobalancing ) {
+      /** Load balancing of the output mesh */
+
+      /* Store user repartitioning mode */
+      int repartitioning_mode;
+      repartitioning_mode = parmesh->info.repartitioning;
+
+      /* Load balance using mesh groups graph */
       parmesh->info.repartitioning = PMMG_REDISTRIBUTION_graph_balancing;
+      ier = PMMG_loadBalancing(parmesh);
+
+      /* Repristinate user repartitioning mode */
+      parmesh->info.repartitioning = repartitioning_mode;
+
+    } else {
+      /** Standard parallel mesh repartitioning */
+      ier = PMMG_loadBalancing(parmesh);
     }
-    ier = PMMG_loadBalancing(parmesh);
+
 
     MPI_Allreduce( &ier, &ieresult, 1, MPI_INT, MPI_MIN, parmesh->comm );
    if ( parmesh->info.imprim > PMMG_VERB_ITWAVES ) {

--- a/src/libparmmg_tools.c
+++ b/src/libparmmg_tools.c
@@ -355,7 +355,9 @@ int PMMG_parsar( int argc, char *argv[], PMMG_pParMesh parmesh )
             ret_val = 0;
             goto fail_proc;
           }
-        }else {
+        } else if ( 0 == strncmp( argv[i], "-nobalance", 9 ) ) {
+          parmesh->info.nobalancing = MMG5_ON;
+        } else {
           ARGV_APPEND(parmesh, argv, mmgArgv, i, mmgArgc,
                       " adding to mmgArgv for mmg: ",
                       ret_val = 0; goto fail_proc );

--- a/src/libparmmgtypes.h
+++ b/src/libparmmgtypes.h
@@ -320,6 +320,7 @@ typedef struct {
   int repartitioning; /*!< way to perform mesh repartitioning */
   int ifc_layers;  /*!< nb of layers for interface displacement */
   double grps_ratio;  /*!< allowed imbalance ratio between current and demanded groups size */
+  int nobalancing; /*!< switch off final load balancing */
   int loadbalancing_mode; /*!< way to perform the loadbalanding (see LOADBALANCING) */
   int contiguous_mode; /*!< force/don't force partitions contiguity */
   int metis_ratio; /*!< wanted ratio between the number of meshes and the number of metis super nodes */

--- a/src/libparmmgtypes.h
+++ b/src/libparmmgtypes.h
@@ -369,6 +369,7 @@ typedef struct {
 
   /* global variables */
   int            ddebug; //! Debug level
+  int            iter;   //! Current adaptation iteration
   int            niter;  //! Number of adaptation iterations
 
   /* parameters of the run */


### PR DESCRIPTION
Repristinate load balancing of the output mesh by default. Add optional parameter -nobalance (PMMG_IPARAM_nobalancing) to switch it off.