### PR TITLE
genheader fix for Fortran header

### DIFF
--- a/scripts/genheader.c
+++ b/scripts/genheader.c
@@ -97,7 +97,7 @@ int main (int argc, char ** argv)
     fprintf(file,"#include \"%s/libparmmgtypesf.h\"\n\n",libparmmg_include);
   }
   else {
-    fprintf(file,"#include \"libmmgtypesf.h\"\n\n");
+    fprintf(file,"#include \"mmg/mmg3d/libmmgtypesf.h\"\n\n");
   }
   fclose(file);
 


### PR DESCRIPTION
I believe this fixes an issue when trying to compile Fortran programs against ParMMG. This makes "libparmmgtypesf.h" similar to "libparmmgtypes.h" with regards to:

`#include "mmg/mmg3d/libmmgtypesf.h"`

as opposed to:

`#include "libmmgtypesf.h"`

which produces an error