### PR TITLE
Change Fortran interface for real variable inputs.

### DIFF
--- a/src/libparmmg.h
+++ b/src/libparmmg.h
@@ -420,7 +420,8 @@ int  PMMG_Set_iparameter(PMMG_pParMesh parmesh, int iparam, int val);
  * \remark Fortran interface:
  * >   SUBROUTINE PMMG_SET_DPARAMETER(parmesh,dparam,val,retval)\n
  * >     MMG5_DATA_PTR_T,INTENT(INOUT) :: parmesh\n
- * >     INTEGER, INTENT(IN)           :: dparam,val\n
+ * >     INTEGER, INTENT(IN)           :: dparam\n
+ * >     REAL(KIND=8), INTENT(IN)      :: val\n
  * >     INTEGER, INTENT(OUT)          :: retval\n
  * >   END SUBROUTINE\n
  *


### PR DESCRIPTION
Hi,

I believe the Fortran interface for real parameter inputs needs to be changed to match the function within ParMMG. Otherwise when using the Fortran API all variable inputs using pmmg_set_deparameter must be ints.

Cheers,
Iain