### PR TITLE
qualhisto: jumps depend on uninitialised values

### DIFF
--- a/src/quality_pmmg.c
+++ b/src/quality_pmmg.c
@@ -184,9 +184,9 @@ int PMMG_qualhisto( PMMG_pParMesh parmesh, int opt, int isCentral )
   iel_grp = 0;
   np = 0;
   ne = 0;
-  max = DBL_MIN;
+  max = max_cur = DBL_MIN;
   avg = 0.;
-  min = DBL_MAX;
+  min = min_cur = DBL_MAX;
   iel = 0;
   good = 0;
   med = 0;


### PR DESCRIPTION
```
==465872== Conditional jump or move depends on uninitialised value(s)
==465872==    at 0x8AE11F1: PMMG_qualhisto (quality_pmmg.c:251)
==465872==    by 0x8A9F516: PMMG_parmmglib1 (libparmmg1.c:911)
==465872==    by 0x8A9872E: PMMG_parmmglib_distributed (libparmmg.c:1616)
==465872==    by 0x5EE4C8E: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:269)
==465872==    by 0x636D661: DMAdaptMetric (dmgenerate.c:254)
==465872==    by 0x10F636: main (ex60.c:238)
==465872==  Uninitialised value was created by a stack allocation
==465872==    at 0x8AE0B13: PMMG_qualhisto (quality_pmmg.c:157)
```