### PR TITLE
Changes to Fortran interface

### DIFF
--- a/src/API_functions_pmmg.c
+++ b/src/API_functions_pmmg.c
@@ -1400,7 +1400,7 @@ int PMMG_Get_NodeCommunicator_nodes(PMMG_pParMesh parmesh, int** local_index) {
   return 1;
 }
 
-int PMMG_Get_NodeCommunicator_nodesf(PMMG_pParMesh parmesh, int ext_comm_index, int* local_index) {
+int PMMG_Get_ithNodeCommunicator_nodes(PMMG_pParMesh parmesh, int ext_comm_index, int* local_index) {
   PMMG_pGrp      grp;
   PMMG_pInt_comm int_node_comm;
   PMMG_pExt_comm ext_node_comm;

--- a/src/API_functions_pmmg.c
+++ b/src/API_functions_pmmg.c
@@ -1398,6 +1398,38 @@ int PMMG_Get_NodeCommunicator_nodes(PMMG_pParMesh parmesh, int** local_index) {
   return 1;
 }
 
+int PMMG_Get_NodeCommunicator_nodesf(PMMG_pParMesh parmesh, int ext_comm_index, int* local_index) {
+  PMMG_pGrp      grp;
+  PMMG_pInt_comm int_node_comm;
+  PMMG_pExt_comm ext_node_comm;
+  MMG5_pMesh     mesh;
+  int            ip,i,idx;
+
+  /* Meshes are merged in grp 0 */
+  int_node_comm = parmesh->int_node_comm;
+  grp  = &parmesh->listgrp[0];
+  mesh = grp->mesh;
+
+
+  /** 1) Store node index in intvalues */
+  PMMG_CALLOC(parmesh,int_node_comm->intvalues,int_node_comm->nitem,int,"intvalues",return 0);
+  for( i = 0; i < grp->nitem_int_node_comm; i++ ){
+    ip   = grp->node2int_node_comm_index1[i];
+    idx  = grp->node2int_node_comm_index2[i];
+    parmesh->int_node_comm->intvalues[idx] = ip;
+  }
+
+  /** 2) For each external communicator, get node index from intvalues */
+  ext_node_comm = &parmesh->ext_node_comm[ext_comm_index];
+  for( i = 0; i < ext_node_comm->nitem; i++ ){
+    idx = ext_node_comm->int_comm_index[i];
+    local_index[i] = int_node_comm->intvalues[idx];
+    }
+
+  PMMG_DEL_MEM(parmesh,int_node_comm->intvalues,int,"intvalues");
+  return 1;
+}
+
 int PMMG_Get_FaceCommunicator_faces(PMMG_pParMesh parmesh, int** local_index) {
   MMG5_Hash      hash;
   PMMG_pGrp      grp;

--- a/src/API_functions_pmmg.c
+++ b/src/API_functions_pmmg.c
@@ -421,6 +421,8 @@ void PMMG_Init_parameters(PMMG_pParMesh parmesh,MPI_Comm comm) {
   parmesh->info.metis_ratio        = PMMG_RATIO_MMG_METIS;
   parmesh->info.API_mode           = PMMG_APIDISTRIB_faces;
   parmesh->info.globalNum          = PMMG_NUL;
+  parmesh->info.globalVNumGot      = PMMG_NUL;
+  parmesh->info.globalTNumGot      = PMMG_NUL;
   parmesh->info.sethmin            = PMMG_NUL;
   parmesh->info.sethmax            = PMMG_NUL;
   parmesh->info.fmtout             = PMMG_FMT_Unknown;
@@ -1898,6 +1900,12 @@ int PMMG_Check_Get_FaceCommunicators(PMMG_pParMesh parmesh,
 int PMMG_Get_triangleGloNum( PMMG_pParMesh parmesh, int *idx_glob, int *owner ) {
   MMG5_pMesh mesh;
   MMG5_pTria ptr;
+  int ier;
+
+  if( !parmesh->info.globalTNumGot ) {
+    ier = PMMG_Compute_trianglesGloNum( parmesh );
+    parmesh->info.globalTNumGot = 1;
+  }
 
   if( !parmesh->info.globalNum ) {
     fprintf(stderr,"\n  ## Error: %s: Triangle global numbering has not been computed.\n",
@@ -1952,7 +1960,12 @@ int PMMG_Get_triangleGloNum( PMMG_pParMesh parmesh, int *idx_glob, int *owner ) 
 int PMMG_Get_trianglesGloNum( PMMG_pParMesh parmesh, int *idx_glob, int *owner ) {
   MMG5_pMesh mesh;
   MMG5_pTria ptr;
-  int        k;
+  int        k,ier;
+
+  if( !parmesh->info.globalTNumGot ) {
+    ier = PMMG_Compute_trianglesGloNum( parmesh );
+    parmesh->info.globalTNumGot = 1;
+  }
 
   if( !parmesh->info.globalNum ) {
     fprintf(stderr,"\n  ## Error: %s: Triangles global numbering has not been computed.\n",
@@ -1987,6 +2000,12 @@ int PMMG_Get_trianglesGloNum( PMMG_pParMesh parmesh, int *idx_glob, int *owner )
 int PMMG_Get_vertexGloNum( PMMG_pParMesh parmesh, int *idx_glob, int *owner ) {
   MMG5_pMesh  mesh;
   MMG5_pPoint ppt;
+  int ier;
+
+  if( !parmesh->info.globalVNumGot ) {
+    ier = PMMG_Compute_verticesGloNum( parmesh );
+    parmesh->info.globalVNumGot = 1;
+  }
 
   if( !parmesh->info.globalNum ) {
     fprintf(stderr,"\n  ## Error: %s: Nodes global numbering has not been computed.\n",
@@ -2040,7 +2059,12 @@ int PMMG_Get_vertexGloNum( PMMG_pParMesh parmesh, int *idx_glob, int *owner ) {
 int PMMG_Get_verticesGloNum( PMMG_pParMesh parmesh, int *idx_glob, int *owner ) {
   MMG5_pMesh  mesh;
   MMG5_pPoint ppt;
-  int         ip;
+  int         ip,ier;
+
+  if( !parmesh->info.globalVNumGot ) {
+    ier = PMMG_Compute_verticesGloNum( parmesh );
+    parmesh->info.globalVNumGot = 1;
+  }
 
   if( !parmesh->info.globalNum ) {
     fprintf(stderr,"\n  ## Error: %s: Nodes global numbering has not been computed.\n",

--- a/src/API_functionsf_pmmg.c
+++ b/src/API_functionsf_pmmg.c
@@ -924,16 +924,13 @@ FORTRAN_NAME(PMMG_GET_NODECOMMUNICATOR_NODES, pmmg_get_nodecommunicator_nodes,
 }
 
 /**
- * See \ref PMMG_Get_NodeCommunicator_nodesf function in \ref libparmmg.h file.
- * adapted version of pmmg_get_nodecommunicator_nodes but returns only a pointer
- * to the shared nodes with the given partition int. Works with Fortran which cannot
- * assign a **int with differing allocations on each index
+ * See \ref PMMG_Get_ithNodeCommunicator_nodes function in \ref libparmmg.h file.
  */
-FORTRAN_NAME(PMMG_GET_NODECOMMUNICATOR_NODESF, pmmg_get_nodecommunicator_nodesf,
+FORTRAN_NAME(PMMG_GET_ITHNODECOMMUNICATOR_NODES, pmmg_get_ithnodecommunicator_nodes,
     (PMMG_pParMesh *parmesh, int* ext_comm_index, int* local_index,
      int* retval),
     (parmesh, ext_comm_index, local_index, retval)) {
-  *retval = PMMG_Get_NodeCommunicator_nodesf(*parmesh,*ext_comm_index,local_index);
+  *retval = PMMG_Get_ithNodeCommunicator_nodes(*parmesh,*ext_comm_index,local_index);
   return;
 }
 

--- a/src/API_functionsf_pmmg.c
+++ b/src/API_functionsf_pmmg.c
@@ -825,6 +825,17 @@ FORTRAN_NAME(PMMG_SET_NUMBEROFNODECOMMUNICATORS, pmmg_set_numberofnodecommunicat
 }
 
 /**
+ * See \ref PMMG_Get_numberOfNodeCommunicators function in \ref libparmmg.h file.
+ */
+FORTRAN_NAME(PMMG_GET_NUMBEROFNODECOMMUNICATORS, pmmg_get_numberofnodecommunicators,
+    (PMMG_pParMesh *parmesh,int* next_comm,
+     int* retval),
+    (parmesh, next_comm, retval)) {
+  *retval = PMMG_Get_numberOfNodeCommunicators(*parmesh,next_comm);
+  return;
+}
+
+/**
  * See \ref PMMG_Set_numberOfFaceCommunicators function in \ref libparmmg.h file.
  */
 FORTRAN_NAME(PMMG_SET_NUMBEROFFACECOMMUNICATORS, pmmg_set_numberoffacecommunicators,

--- a/src/API_functionsf_pmmg.c
+++ b/src/API_functionsf_pmmg.c
@@ -924,6 +924,20 @@ FORTRAN_NAME(PMMG_GET_NODECOMMUNICATOR_NODES, pmmg_get_nodecommunicator_nodes,
 }
 
 /**
+ * See \ref PMMG_Get_NodeCommunicator_nodesf function in \ref libparmmg.h file.
+ * adapted version of pmmg_get_nodecommunicator_nodes but returns only a pointer
+ * to the shared nodes with the given partition int. Works with Fortran which cannot
+ * assign a **int with differing allocations on each index
+ */
+FORTRAN_NAME(PMMG_GET_NODECOMMUNICATOR_NODESF, pmmg_get_nodecommunicator_nodesf,
+    (PMMG_pParMesh *parmesh, int* ext_comm_index, int* local_index,
+     int* retval),
+    (parmesh, ext_comm_index, local_index, retval)) {
+  *retval = PMMG_Get_NodeCommunicator_nodesf(*parmesh,*ext_comm_index,local_index);
+  return;
+}
+
+/**
  * See \ref PMMG_Get_FaceCommunicator_faces function in \ref libparmmg.h file.
  */
 FORTRAN_NAME(PMMG_GET_FACECOMMUNICATOR_FACES, pmmg_get_facecommunicator_faces,

--- a/src/libparmmg.h
+++ b/src/libparmmg.h
@@ -2189,7 +2189,7 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
  * \remark Fortran interface:
  * >   SUBROUTINE PMMG_GET_ITHNODECOMMUNICATORSIZE(parmesh,ext_comm_index,color_out,nitem,retval)\n
  * >     MMG5_DATA_PTR_T, INTENT(INOUT) :: parmesh\n
- * >     INTEGER, INTENT(OUT)           :: ext_comm_index\n
+ * >     INTEGER, INTENT(IN)            :: ext_comm_index\n
  * >     INTEGER, INTENT(OUT)           :: color_out\n
  * >     INTEGER, INTENT(OUT)           :: nitem\n
  * >     INTEGER, INTENT(OUT)           :: retval\n
@@ -2210,7 +2210,7 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
  * \remark Fortran interface:
  * >   SUBROUTINE PMMG_GET_ITHFACECOMMUNICATORSIZE(parmesh,ext_comm_index,color_out,nitem,retval)\n
  * >     MMG5_DATA_PTR_T, INTENT(INOUT) :: parmesh\n
- * >     INTEGER, INTENT(OUT)           :: ext_comm_index\n
+ * >     INTEGER, INTENT(IN)            :: ext_comm_index\n
  * >     INTEGER, INTENT(OUT)           :: color_out\n
  * >     INTEGER, INTENT(OUT)           :: nitem\n
  * >     INTEGER, INTENT(OUT)           :: retval\n
@@ -2219,14 +2219,13 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
   int PMMG_Get_ithFaceCommunicatorSize(PMMG_pParMesh parmesh, int ext_comm_index, int *color_out, int *nitem);
 /**
  * \param parmesh pointer toward the parmesh structure
- * \param ext_comm_index index of the communicator
  * \param local_index array of local mesh IDs of interface entities
  * \return 0 if failed, 1 otherwise.
  *
  * Get the nodes on a parallel interface.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE PMMG_GET_ITHNODECOMMUNICATOR_NODES(parmesh,local_index,retval)\n
+ * >   SUBROUTINE PMMG_GET_NODECOMMUNICATOR_NODES(parmesh,local_index,retval)\n
  * >     MMG5_DATA_PTR_T, INTENT(INOUT)       :: parmesh\n
  * >     INTEGER, DIMENSION(*), INTENT(OUT)   :: local_index\n
  * >     INTEGER, INTENT(OUT)                 :: retval\n
@@ -2243,7 +2242,7 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
  * Get the faces on a parallel interface.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE PMMG_GET_ITHFACECOMMUNICATOR_NODES(parmesh,local_index,retval)\n
+ * >   SUBROUTINE PMMG_GET_ITHFACECOMMUNICATOR_FACES(parmesh,local_index,retval)\n
  * >     MMG5_DATA_PTR_T, INTENT(INOUT)       :: parmesh\n
  * >     INTEGER, DIMENSION(*), INTENT(OUT)   :: local_index\n
  * >     INTEGER, INTENT(OUT)                 :: retval\n

--- a/src/libparmmg.h
+++ b/src/libparmmg.h
@@ -2260,7 +2260,7 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
  * Get the faces on a parallel interface.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE PMMG_GET_ITHFACECOMMUNICATOR_FACES(parmesh,local_index,retval)\n
+ * >   SUBROUTINE PMMG_GET_FACECOMMUNICATOR_FACES(parmesh,local_index,retval)\n
  * >     MMG5_DATA_PTR_T, INTENT(INOUT)       :: parmesh\n
  * >     INTEGER, DIMENSION(*), INTENT(OUT)   :: local_index\n
  * >     INTEGER, INTENT(OUT)                 :: retval\n

--- a/src/libparmmg.h
+++ b/src/libparmmg.h
@@ -2222,6 +2222,10 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
  * \param local_index array of local mesh IDs of interface entities
  * \return 0 if failed, 1 otherwise.
  *
+ * \warning Non callable from a fortran code as Fortran cannot assign a **int
+ * with differing allocations on each index.
+ * \ref PMMG_Get_ithNodeCommunicator_nodes should be used instead.
+ *
  * Get the nodes on a parallel interface.
  *
  * \remark Fortran interface:
@@ -2239,10 +2243,11 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
  * \param local_index array of local mesh IDs of specified interface entities
  * \return 0 if failed, 1 otherwise.
  *
- * Get the nodes on a parallel interface. For Fortran use PMMG_Get_NodeCommunicator_nodesf
+ * Get the nodes on a parallel interface for a given node communicator.
+ * To be used for Fortran users in place of \ref PMMG_Get_NodeCommunicator_nodes.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE PMMG_GET_NODECOMMUNICATOR_NODESF(parmesh,ext_comm_index,local_index,retval)\n
+ * >   SUBROUTINE PMMG_GET_ITHNODECOMMUNICATOR_NODES(parmesh,ext_comm_index,local_index,retval)\n
  * >     MMG5_DATA_PTR_T, INTENT(INOUT)       :: parmesh\n
  * >     INTEGER, INTENT(IN)                  :: ext_comm_index\n
  * >     INTEGER, DIMENSION(*), INTENT(OUT)   :: local_index\n
@@ -2250,7 +2255,7 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
  * >   END SUBROUTINE\n
  *
  */
-  int PMMG_Get_NodeCommunicator_nodesf(PMMG_pParMesh parmesh, int ext_comm_index, int* local_index);
+  int PMMG_Get_ithNodeCommunicator_nodes(PMMG_pParMesh parmesh, int ext_comm_index, int* local_index);
 /**
  * \param parmesh pointer toward the parmesh structure
  * \param ext_comm_index index of the communicator

--- a/src/libparmmg.h
+++ b/src/libparmmg.h
@@ -2236,6 +2236,24 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename);
 /**
  * \param parmesh pointer toward the parmesh structure
  * \param ext_comm_index index of the communicator
+ * \param local_index array of local mesh IDs of specified interface entities
+ * \return 0 if failed, 1 otherwise.
+ *
+ * Get the nodes on a parallel interface. For Fortran use PMMG_Get_NodeCommunicator_nodesf
+ *
+ * \remark Fortran interface:
+ * >   SUBROUTINE PMMG_GET_NODECOMMUNICATOR_NODESF(parmesh,ext_comm_index,local_index,retval)\n
+ * >     MMG5_DATA_PTR_T, INTENT(INOUT)       :: parmesh\n
+ * >     INTEGER, INTENT(IN)                  :: ext_comm_index\n
+ * >     INTEGER, DIMENSION(*), INTENT(OUT)   :: local_index\n
+ * >     INTEGER, INTENT(OUT)                 :: retval\n
+ * >   END SUBROUTINE\n
+ *
+ */
+  int PMMG_Get_NodeCommunicator_nodesf(PMMG_pParMesh parmesh, int ext_comm_index, int* local_index);
+/**
+ * \param parmesh pointer toward the parmesh structure
+ * \param ext_comm_index index of the communicator
  * \param local_index array of local mesh IDs of interface entities
  * \return 0 if failed, 1 otherwise.
  *

--- a/src/libparmmgtypes.h
+++ b/src/libparmmgtypes.h
@@ -329,6 +329,8 @@ typedef struct {
   int target_mesh_size; /*!< target mesh size for Mmg */
   int API_mode; /*!< use faces or nodes information to build communicators */
   int globalNum; /*!< compute nodes and triangles global numbering in output */
+  int globalVNumGot; /*!< have global nodes actually been calculated */
+  int globalTNumGot; /*!< have global triangles actually been calculated */
   int fmtout; /*!< store the output format asked */
   int8_t sethmin; /*!< 1 if user set hmin, 0 otherwise (needed for multiple library calls) */
   int8_t sethmax; /*!< 1 if user set hmin, 0 otherwise (needed for multiple library calls) */

--- a/src/parmmg.h
+++ b/src/parmmg.h
@@ -479,6 +479,7 @@ void PMMG_grp_comm_free( PMMG_pParMesh ,int**,int**,int*);
 void PMMG_node_comm_free( PMMG_pParMesh );
 void PMMG_edge_comm_free( PMMG_pParMesh );
 int PMMG_Compute_verticesGloNum( PMMG_pParMesh parmesh );
+int PMMG_Compute_trianglesGloNum( PMMG_pParMesh parmesh );
 int PMMG_color_commNodes( PMMG_pParMesh parmesh );
 void PMMG_tria2elmFace_flags( PMMG_pParMesh parmesh );
 void PMMG_tria2elmFace_coords( PMMG_pParMesh parmesh );


### PR DESCRIPTION
I've made three changes each relates to one of my commits:

1: Fixes of bugs in API Fortran interface.
2: Addition of a new function PMMG_Get_NodeCommunicatorsf. Differs from the original function as it only returns the shared node information for a given neighbouring partition. This is because Fortran does not have the functionality to create a pointer pointer with different memory allocations on each index. Therefore the original function was not usable and just segfaulted.
3: Addition of a check when recovering global node/triangle numbers to check they have been calculated. Previously they are only calculated if the mesh was saved to file which always done when using the API.

I have created the pull request to the feature/tetFromTria-API as it had some added API functions required for Fortran interfacing.

With these changes  ParMMG works with ElmerFEM (and Elmer/Ice) for both centralised and distributed meshes.

Let me know if you need any more information.

Best,
Iain