### PR TITLE
Fix a conditional jump

### DIFF
--- a/src/locate_pmmg.c
+++ b/src/locate_pmmg.c
@@ -591,7 +591,7 @@ int PMMG_locatePointBdy( MMG5_pMesh mesh,MMG5_pPoint ppt,
   MMG5_pTria     ptr,ptr1;
   int            *adjt,j,i,k,k1,kprev,step,closestTria,stuck,backward;
   int            iloc;
-  double         vol,eps,h,closestDist;
+  double         vol,eps,h=DBL_MAX,closestDist;
   static int     mmgWarn0=0,mmgWarn1=0;
   int            ier;
 


### PR DESCRIPTION
```
==206307== Conditional jump or move depends on uninitialised value(s)
==206307==    at 0xC4A395C: PMMG_locatePoint_foundConvex (locate_pmmg.c:556)
==206307==    by 0xC4A3E9F: PMMG_locatePointBdy (locate_pmmg.c:689)
==206307==    by 0xC481C3B: PMMG_interpMetricsAndFields_mesh (interpmesh_pmmg.c:557)
==206307==    by 0xC482683: PMMG_interpMetricsAndFields (interpmesh_pmmg.c:717)
==206307==    by 0xC497EF3: PMMG_parmmglib1 (libparmmg1.c:830)
==206307==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==206307==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==206307==    by 0x63EFF57: DMAdaptMetric (dmgenerate.c:248)
==206307==    by 0x10FCCB: main (ex60.c:253)
```
Sadly, after using `feature/anisomet` (or a fresh `develop` since this is now merged) from Mmg, I still get tons of Valgrind errors.
```
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7D17E48: MMG5_rotmatrix (tools.c:462)
==248412==    by 0x7D09827: MMG5_interpreg_ani (intmet.c:637)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==    by 0x63EFF57: DMAdaptMetric (dmgenerate.c:248)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7D17E6B: MMG5_rotmatrix (tools.c:462)
==248412==    by 0x7D09827: MMG5_interpreg_ani (intmet.c:637)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7D17E80: MMG5_rotmatrix (tools.c:465)
==248412==    by 0x7D09827: MMG5_interpreg_ani (intmet.c:637)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==    by 0x63EFF57: DMAdaptMetric (dmgenerate.c:248)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7D17F87: MMG5_rotmatrix (tools.c:478)
==248412==    by 0x7D09827: MMG5_interpreg_ani (intmet.c:637)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF20D8: MMG5_eigenv3d (eigenv.c:406)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2110: MMG5_eigenv3d (eigenv.c:409)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2250: MMG5_eigenv3d (eigenv.c:431)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2278: MMG5_eigenv3d (eigenv.c:433)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2294: MMG5_eigenv3d (eigenv.c:434)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF0F3C: newton3 (eigenv.c:120)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF0F4B: newton3 (eigenv.c:121)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1030: newton3 (eigenv.c:131)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1048: newton3 (eigenv.c:131)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1124: newton3 (eigenv.c:148)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF113C: newton3 (eigenv.c:148)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF13CC: newton3 (eigenv.c:211)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1444: newton3 (eigenv.c:219)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF13DC: newton3 (eigenv.c:211)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF15BC: newton3 (eigenv.c:256)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF15F7: newton3 (eigenv.c:261)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1690: newton3 (eigenv.c:265)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF16C4: newton3 (eigenv.c:265)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF16FC: newton3 (eigenv.c:266)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF29F0: MMG5_eigenv3d (eigenv.c:545)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2B70: MMG5_eigenv3d (eigenv.c:560)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF2B7F: MMG5_eigenv3d (eigenv.c:561)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2A04: MMG5_eigenv3d (eigenv.c:546)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF2ABF: MMG5_eigenv3d (eigenv.c:553)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF2A13: MMG5_eigenv3d (eigenv.c:547)
==248412==    by 0x7D06487: MMG5_mmgIntmet33_ani (intmet.c:57)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7D06510: MMG5_mmgIntmet33_ani (intmet.c:68)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==    by 0x63EFF57: DMAdaptMetric (dmgenerate.c:248)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7D0653B: MMG5_mmgIntmet33_ani (intmet.c:69)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF20D8: MMG5_eigenv3d (eigenv.c:406)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2110: MMG5_eigenv3d (eigenv.c:409)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2250: MMG5_eigenv3d (eigenv.c:431)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2278: MMG5_eigenv3d (eigenv.c:433)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2294: MMG5_eigenv3d (eigenv.c:434)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF0F3C: newton3 (eigenv.c:120)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF0F4B: newton3 (eigenv.c:121)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1030: newton3 (eigenv.c:131)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1048: newton3 (eigenv.c:131)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1124: newton3 (eigenv.c:148)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF113C: newton3 (eigenv.c:148)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF13CC: newton3 (eigenv.c:211)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1444: newton3 (eigenv.c:219)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF13DC: newton3 (eigenv.c:211)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF15BC: newton3 (eigenv.c:256)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF15F7: newton3 (eigenv.c:261)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF1690: newton3 (eigenv.c:265)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF16C4: newton3 (eigenv.c:265)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF16FC: newton3 (eigenv.c:266)
==248412==    by 0x7CF281B: MMG5_eigenv3d (eigenv.c:514)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF29F0: MMG5_eigenv3d (eigenv.c:545)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2B70: MMG5_eigenv3d (eigenv.c:560)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF2B7F: MMG5_eigenv3d (eigenv.c:561)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7CF2A04: MMG5_eigenv3d (eigenv.c:546)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF2A13: MMG5_eigenv3d (eigenv.c:547)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7CF2ABF: MMG5_eigenv3d (eigenv.c:553)
==248412==    by 0x7D06B07: MMG5_mmgIntmet33_ani (intmet.c:103)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7D06D38: MMG5_mmgIntmet33_ani (intmet.c:127)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==    by 0x63EFF57: DMAdaptMetric (dmgenerate.c:248)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7EA6F98: sqrt (w_sqrt_compat.c:31)
==248412==    by 0x7D06D5F: MMG5_mmgIntmet33_ani (intmet.c:128)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7D06D9C: MMG5_mmgIntmet33_ani (intmet.c:130)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==    by 0x63EFF57: DMAdaptMetric (dmgenerate.c:248)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7D18760: MMG5_invmatg (tools.c:608)
==248412==    by 0x7D06E07: MMG5_mmgIntmet33_ani (intmet.c:134)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
==248412== 
==248412== Conditional jump or move depends on uninitialised value(s)
==248412==    at 0x7D18790: MMG5_invmatg (tools.c:610)
==248412==    by 0x7D06E07: MMG5_mmgIntmet33_ani (intmet.c:134)
==248412==    by 0x7D0986B: MMG5_interpreg_ani (intmet.c:642)
==248412==    by 0x7CE2FAB: MMG5_elementWeight (anisomovpt.c:100)
==248412==    by 0x7D3AFAF: MMG5_movbdyregpt_ani (anisomovpt_3d.c:252)
==248412==    by 0x7DA1E87: MMG5_movtet (mmg3d1.c:786)
==248412==    by 0x7DB3DB3: MMG5_adpsplcol (mmg3d1_delone.c:993)
==248412==    by 0x7DB4BDB: MMG5_adptet_delone (mmg3d1_delone.c:1289)
==248412==    by 0x7DB50C3: MMG5_mmg3d1_delone (mmg3d1_delone.c:1392)
==248412==    by 0xC49730B: PMMG_parmmglib1 (libparmmg1.c:740)
==248412==    by 0xC4913E3: PMMG_parmmglib_distributed (libparmmg.c:1744)
==248412==    by 0x617303F: DMAdaptMetric_ParMmg_Plex (parmmgadapt.c:277)
==248412==  Uninitialised value was created by a stack allocation
==248412==    at 0x7D08850: MMG5_interpreg_ani (intmet.c:499)
[...]
```