### PR TITLE
If ls_val is not given in argument, need to go through mmg option parser

### DIFF
--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -317,17 +317,66 @@ IF( BUILD_TESTING )
   #####
   ###############################################################################
   foreach( NP 1 2 4 8 )
-    add_test( NAME ls-arg-option-${NP}
+    add_test( NAME ls-arg-option-detection-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/LevelSet/3D-cube.mesh
       -ls 0.01
       -sol ${CI_DIR}/LevelSet/3D-cube-ls.sol
       -out ${CI_DIR_RESULTS}/${MESH}-${NP}.o.mesh)
     set(lsNotImplemented "## Error: level-set discretisation unavailable")
-    set_property(TEST ls-arg-option-${NP}
+    set_property(TEST ls-arg-option-detection-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsNotImplemented}")
   endforeach()
 
+  # Check that the ls file is correctly opened with or without the ls value given
+  set(lsOpenFile "3D-cube-ls.sol OPENED")
+  set(lsOpenFileDefault "3D-cube.sol  NOT FOUND. USE DEFAULT METRIC.")
+
+  # Test of opening ls file when ls val is given
+  foreach( NP 1 2)
+    add_test( NAME ls-arg-option-openlsfile-lsval-${NP}
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/3D-cube.mesh
+      -ls 0.0
+      -sol ${CI_DIR}/LevelSet/3D-cube-ls.sol
+      -out ${CI_DIR_RESULTS}/${MESH}-${NP}.o.mesh)
+    set_property(TEST ls-arg-option-openlsfile-lsval-${NP}
+      PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
+  endforeach()
+
+  # Test of opening ls file when ls val is not given
+  foreach( NP 1 2)
+    add_test( NAME ls-arg-option-openlsfile-nolsval-${NP}
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/3D-cube.mesh
+      -ls
+      -sol ${CI_DIR}/LevelSet/3D-cube-ls.sol
+      -out ${CI_DIR_RESULTS}/${MESH}-${NP}.o.mesh)
+    set_property(TEST ls-arg-option-openlsfile-nolsval-${NP}
+      PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
+  endforeach()
+
+  # Test of opening ls file with a default name when ls val is given
+  foreach( NP 1 2)
+    add_test( NAME ls-arg-option-openlsfiledefault-lsval-${NP}
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/3D-cube.mesh
+      -ls 0.0
+      -out ${CI_DIR_RESULTS}/${MESH}-${NP}.o.mesh)
+    set_property(TEST ls-arg-option-openlsfiledefault-lsval-${NP}
+      PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
+  endforeach()
+
+  # Test of opening ls file with a default name when ls val is not given
+  foreach( NP 1 2)
+    add_test( NAME ls-arg-option-openlsfiledefault-nolsval-${NP}
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/3D-cube.mesh
+      -ls
+      -out ${CI_DIR_RESULTS}/${MESH}-${NP}.o.mesh)
+    set_property(TEST ls-arg-option-openlsfiledefault-nolsval-${NP}
+      PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
+  endforeach()
 
   ###############################################################################
   #####

--- a/src/libparmmg_tools.c
+++ b/src/libparmmg_tools.c
@@ -312,6 +312,11 @@ int PMMG_parsar( int argc, char *argv[], PMMG_pParMesh parmesh )
                 goto fail_proc;
               }
             }
+            else {
+              ARGV_APPEND(parmesh, argv, mmgArgv, i, mmgArgc,
+                          " adding to mmgArgv for mmg: ",
+                          ret_val = 0; goto fail_proc );
+            }
           }
           else i--;
         }


### PR DESCRIPTION
If the value of the level was not given as arguments, ParMmg was failing to identify the solution file as the level-set file.
This fix append the mmg arguments into `PMMG_parsar` to be able to support this.
Tests were also added.