### PR TITLE
Feature/fix citest multidom distrib

### DIFF
--- a/src/libparmmg_tools.c
+++ b/src/libparmmg_tools.c
@@ -501,7 +501,7 @@ int PMMG_parsar( int argc, char *argv[], PMMG_pParMesh parmesh )
   /** Step 5: Transfer options parsed by Mmg toward ParMmg (if needed) and raise
    * errors for unsupported options */
   parmesh->info.iso = parmesh->listgrp[0].mesh->info.iso;
-  parmesh->info.fem = parmesh->listgrp[0].mesh->info.fem;
+  parmesh->info.fem = parmesh->listgrp[0].mesh->info.setfem;
   parmesh->info.sethmin = parmesh->listgrp[0].mesh->info.sethmin;
   parmesh->info.sethmax = parmesh->listgrp[0].mesh->info.sethmax;
 

--- a/src/parmmg.c
+++ b/src/parmmg.c
@@ -491,13 +491,12 @@ check_mesh_loading:
       }
       break;
     }
-    /* Check output success */
-    if ( ierSave<1 ) {
-      PMMG_RETURN_AND_FREE(parmesh,PMMG_STRONGFAILURE);
-    }
   }
 
-
+  /* Check output success */
+  if ( ierSave<1 ) {
+    PMMG_RETURN_AND_FREE(parmesh,PMMG_STRONGFAILURE);
+  }
 
   chrono(OFF,&PMMG_ctim[tim]);
   if ( parmesh->info.imprim > PMMG_VERB_VERSION )

--- a/src/parmmg.c
+++ b/src/parmmg.c
@@ -491,12 +491,13 @@ check_mesh_loading:
       }
       break;
     }
+    /* Check output success */
+    if ( ierSave<1 ) {
+      PMMG_RETURN_AND_FREE(parmesh,PMMG_STRONGFAILURE);
+    }
   }
 
-  /* Check ouput success */
-  if ( ierSave<1 ) {
-    PMMG_RETURN_AND_FREE(parmesh,PMMG_STRONGFAILURE);
-  }
+
 
   chrono(OFF,&PMMG_ctim[tim]);
   if ( parmesh->info.imprim > PMMG_VERB_VERSION )


### PR DESCRIPTION
The ci test `multidom_wave-8-distrib_parRidge` was failing. This PR fixes this.
1. The variable `parmesh->info.fem` is now initialized using `parmesh->listgrp[0].mesh->info.setfem` instead of `parmesh->listgrp[0].mesh->info.fem`.
2. Fix a typo.