### PR TITLE
Fix memory errors due to the call of functions on null pointers (mems…

### DIFF
--- a/src/interactionmap_pmmg.c
+++ b/src/interactionmap_pmmg.c
@@ -171,7 +171,13 @@ int PMMG_interactionMap(PMMG_pParMesh parmesh,int **interactions,int **interacti
   receivers = NULL;
   PMMG_MALLOC   ( parmesh,receivers,    nrecv_max*nprocs,int,"receivers"   ,ier=0 );
   PMMG_REALLOC  ( parmesh,interact_list,nrecv_max,nneighs_max,int,"interact_list" ,ier=0 );
-  memset ( interact_list,0, nrecv_max * sizeof(int) );
+
+  if ( nrecv_max ) {
+    /* calling memset on a non-allocatted array, leads to
+     * have a NULL pointer that is evaluated to True inside a if
+     * test */
+    memset ( interact_list,0, nrecv_max * sizeof(int) );
+  }
 
   idx = 0;
   for ( k=0; k<nprocs; ++k ) {

--- a/src/linkedlist_pmmg.c
+++ b/src/linkedlist_pmmg.c
@@ -533,7 +533,13 @@ int PMMG_sort_iarray( PMMG_pParMesh parmesh,int *array1,int *array2,int *oldIdx,
   }
 
   /* Sort lists based on values in array2, in ascending order */
-  qsort(cell,nitem,sizeof(PMMG_lnkdCell),PMMG_compare_cell2);
+  if ( nitem ) {
+    /* as memset, calling qsort on a non-allocatted array, leads to
+     * have a NULL pointer that is evaluated to True inside a if
+     * test */
+    qsort(cell,nitem,sizeof(PMMG_lnkdCell),PMMG_compare_cell2);
+  }
+
 
   /* Permute arrays and deallocate lists */
   if ( array1 ) {


### PR DESCRIPTION
…et and qsort): these functions doesn't expect null pointers, after their calls the point still prints NULL, 0 and (nil) values with %s, %d and %p format but evaluates to 1 inside if tests.