### PR TITLE
Fix some bugs in *.pvtu output

### DIFF
--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -392,7 +392,7 @@ IF( BUILD_TESTING )
 
   # Tests of pvtu output when ls mode
   IF ( (NOT VTK_FOUND) OR USE_VTK MATCHES OFF )
-    set(OutputVtkErr "VTK library not founded.")
+    set(OutputVtkErr "VTK library not found.")
   ENDIF ( )
 
   foreach( NP 1 2 4 8 )

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -213,6 +213,26 @@ IF( BUILD_TESTING )
       ${myargs}
       )
 
+    # Tests for distributed pvtu output with dots in filename.
+    # Replacement of dots by dashes.
+    IF ( (NOT VTK_FOUND) OR USE_VTK MATCHES OFF )
+      set(OutputVtkErr "VTK library not found.")
+    ENDIF ( )
+
+    set(OutputVtkRenameFilename "3D-cube-PvtuOut-2-a-o.pvtu")
+    set(OutputVtkRenameWarning  "## WARNING: Filename has been changed.")
+
+    add_test( NAME PvtuOut-RenameOut-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+      -out ${CI_DIR_RESULTS}/3D-cube-PvtuOut-2.a.o.pvtu)
+
+    set_property(TEST PvtuOut-RenameOut-2
+      PROPERTY PASS_REGULAR_EXPRESSION
+      "${OutputVtkRenameFilename}.*${OutputVtkRenameWarning}.*${OutputVtkErr};
+       ${OutputVtkRenameWarning}.*${OutputVtkErr}.*${OutputVtkRenameFilename};
+       ${OutputVtkRenameFilename}.*${OutputVtkErr}.*${OutputVtkRenameWarning}")
+
     ###############################################################################
     #####
     #####        Tests fields interpolation with or without metric
@@ -326,7 +346,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls 0.0
       -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-${NP}-out.mesh)
+      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-${NP}.o.mesh)
   endforeach()
 
   # Check that the ls file is correctly opened with or without the ls value given
@@ -340,7 +360,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls 0.0
       -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-lsval-${NP}-out.mesh)
+      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-lsval-${NP}.o.mesh)
     set_property(TEST ls-arg-option-openlsfile-lsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
   endforeach()
@@ -352,7 +372,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls
       -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-nolsval-${NP}-out.mesh)
+      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-nolsval-${NP}.o.mesh)
     set_property(TEST ls-arg-option-openlsfile-nolsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
   endforeach()
@@ -363,7 +383,7 @@ IF( BUILD_TESTING )
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls 0.0
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-lsval-${NP}-out.mesh)
+      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-lsval-${NP}.o.mesh)
     set_property(TEST ls-arg-option-openlsfiledefault-lsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
   endforeach()
@@ -374,7 +394,7 @@ IF( BUILD_TESTING )
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-nolsval-${NP}-out.mesh)
+      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-nolsval-${NP}.o.mesh)
     set_property(TEST ls-arg-option-openlsfiledefault-nolsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
   endforeach()
@@ -387,14 +407,10 @@ IF( BUILD_TESTING )
     -ls 0.0
     -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
     -met ${CI_DIR}/LevelSet/centralized/3D-cube-metric.sol
-    -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-met-${NP}-out.mesh)
+    -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-met-${NP}.o.mesh)
   endforeach()
 
-  # Tests of pvtu output when ls mode
-  IF ( (NOT VTK_FOUND) OR USE_VTK MATCHES OFF )
-    set(OutputVtkErr "VTK library not found.")
-  ENDIF ( )
-
+  # Tests of distributed pvtu output when ls mode
   foreach( NP 1 2 4 8 )
     add_test( NAME ls-CenIn-DisOut-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
@@ -416,7 +432,7 @@ IF( BUILD_TESTING )
     ${CI_DIR}/LevelSet/distributed/3D-cube.mesh -v 10
     -ls 0.01
     -sol ${CI_DIR}/LevelSet/distributed/3D-cube-ls.sol
-    -out ${CI_DIR_RESULTS}/ls-DisIn-ReadLs-2-out.mesh)
+    -out ${CI_DIR_RESULTS}/ls-DisIn-ReadLs-2.o.mesh)
   set(lsReadFile "3D-cube-ls.0.sol OPENED")
   set_property(TEST ls-DisIn-ReadLs-2
     PROPERTY PASS_REGULAR_EXPRESSION "${lsReadFile}")
@@ -518,18 +534,18 @@ IF( BUILD_TESTING )
   set_property(TEST fields-DisIn-DisOutVTK-2
     PROPERTY PASS_REGULAR_EXPRESSION
     "${InputDistributedFields}.*${OutputVtkFields}.*${OutputVtkErr};
-${OutputVtkFields}.*${OutputVtkErr}.*${InputDistributedFields};
-${InputDistributedFields}.*${OutputVtkErr}.*${OutputVtkFields}")
+     ${OutputVtkFields}.*${OutputVtkErr}.*${InputDistributedFields};
+     ${InputDistributedFields}.*${OutputVtkErr}.*${OutputVtkFields}")
 
   # Test to write distributed output fields and metric in Medit format
   add_test( NAME fields-DisIn-DisOutMesh-2
     COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
     ${CI_DIR}/LevelSet/distributed/3D-cube.mesh
     -field ${CI_DIR}/LevelSet/distributed/3D-cube-fields.sol
-    -out ${CI_DIR_RESULTS}/3D-cube-fields-DisIn-DisOutMesh-2-out.mesh)
+    -out ${CI_DIR_RESULTS}/3D-cube-fields-DisIn-DisOutMesh-2.o.mesh)
 
   set(OutputFieldsName "3D-cube-fields.o.0.sol OPENED.")
-  set(OutputMetricName "3D-cube-fields-DisIn-DisOutMesh-2-out.0.sol OPENED.")
+  set(OutputMetricName "3D-cube-fields-DisIn-DisOutMesh-2.o.0.sol OPENED.")
   set_property(TEST fields-DisIn-DisOutMesh-2
     PROPERTY PASS_REGULAR_EXPRESSION
     "${OutputFieldsName}.*${OutputMetricName};${OutputMetricName}.*${OutputFieldsName}")

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -326,7 +326,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls 0.0
       -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-${NP}.o.mesh)
+      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-${NP}-out.mesh)
   endforeach()
 
   # Check that the ls file is correctly opened with or without the ls value given
@@ -340,7 +340,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls 0.0
       -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-lsval-${NP}.o.mesh)
+      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-lsval-${NP}-out.mesh)
     set_property(TEST ls-arg-option-openlsfile-lsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
   endforeach()
@@ -352,7 +352,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls
       -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-nolsval-${NP}.o.mesh)
+      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-nolsval-${NP}-out.mesh)
     set_property(TEST ls-arg-option-openlsfile-nolsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
   endforeach()
@@ -363,7 +363,7 @@ IF( BUILD_TESTING )
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls 0.0
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-lsval-${NP}.o.mesh)
+      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-lsval-${NP}-out.mesh)
     set_property(TEST ls-arg-option-openlsfiledefault-lsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
   endforeach()
@@ -374,7 +374,7 @@ IF( BUILD_TESTING )
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-nolsval-${NP}.o.mesh)
+      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-nolsval-${NP}-out.mesh)
     set_property(TEST ls-arg-option-openlsfiledefault-nolsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
   endforeach()
@@ -387,7 +387,7 @@ IF( BUILD_TESTING )
     -ls 0.0
     -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
     -met ${CI_DIR}/LevelSet/centralized/3D-cube-metric.sol
-    -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-met-${NP}.o.mesh)
+    -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-met-${NP}-out.mesh)
   endforeach()
 
   # Tests of pvtu output when ls mode
@@ -401,7 +401,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
       -ls 0.0
       -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-DisOut-${NP}.o.pvtu)
+      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-DisOut-${NP}-out.pvtu)
 
     set_property(TEST ls-CenIn-DisOut-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${OutputVtkErr}")
@@ -416,7 +416,7 @@ IF( BUILD_TESTING )
     ${CI_DIR}/LevelSet/distributed/3D-cube.mesh -v 10
     -ls 0.01
     -sol ${CI_DIR}/LevelSet/distributed/3D-cube-ls.sol
-    -out ${CI_DIR_RESULTS}/ls-DisIn-ReadLs-2.o.mesh)
+    -out ${CI_DIR_RESULTS}/ls-DisIn-ReadLs-2-out.mesh)
   set(lsReadFile "3D-cube-ls.0.sol OPENED")
   set_property(TEST ls-DisIn-ReadLs-2
     PROPERTY PASS_REGULAR_EXPRESSION "${lsReadFile}")

--- a/src/inoutcpp_pmmg.cpp
+++ b/src/inoutcpp_pmmg.cpp
@@ -97,7 +97,7 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename) {
   strcpy(mdata,filename);
   char *ptr = MMG5_Get_filenameExt(mdata);
   *ptr = '\0'; // get basename
-  snprintf( sdata,strlen(mdata)+100, "%s.pvtu",mdata);
+  snprintf( sdata,strlen(mdata)+6, "%s.pvtu",mdata);
 
   MMG5_pMesh mesh = parmesh->listgrp[0].mesh;
   MMG5_pSol  met  = parmesh->listgrp[0].met;
@@ -140,7 +140,7 @@ int PMMG_savePvtuMesh_and_allData(PMMG_pParMesh parmesh, const char * filename) 
   strcpy(mdata,filename);
   char *ptr = MMG5_Get_filenameExt(mdata);
   *ptr = '\0'; // get basename
-  snprintf( sdata,strlen(mdata), "%s.pvtu",mdata);
+  snprintf( sdata,strlen(mdata)+6, "%s.pvtu",mdata);
 
   mesh  = parmesh->listgrp[0].mesh;
   // Add met at the end of field to be able to save everything in the pvtu file

--- a/src/inoutcpp_pmmg.cpp
+++ b/src/inoutcpp_pmmg.cpp
@@ -99,12 +99,12 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename) {
   char *ptr = MMG5_Get_filenameExt(mdata);
   *ptr = '\0'; // get basename
 
-  // If the output *.pvtu filename has dots "." in the filename,
-  // replace the dots "." with dashes "-".
+  // If the output *.pvtu filename has dots "." in the basename,
+  // replace them with dashes "-".
   // Why? In VTK function SetFileName(filename), the first dot "." in the
   // filename is interpreted as the extension start. So, whatever the
   // user specifies after the first dot "." will be ignored by VTK. To overcome
-  // this and avoid to rewrite on input data, we are replacing the dots by dashes.
+  // this, dots are replaced by dashes.
   for(i=0;mdata[i]!='\0';i++) {
     if(mdata[i]=='.') {
       mdata[i] = '-';
@@ -156,12 +156,12 @@ int PMMG_savePvtuMesh_and_allData(PMMG_pParMesh parmesh, const char * filename) 
   char *ptr = MMG5_Get_filenameExt(mdata);
   *ptr = '\0'; // get basename
 
-  // If the output *.pvtu filename has dots "." in the filename,
-  // replace the dots "." with dashes "-".
+  // If the output *.pvtu filename has dots "." in the basename,
+  // replace them with dashes "-".
   // Why? In VTK function SetFileName(filename), the first dot "." in the
   // filename is interpreted as the extension start. So, whatever the
   // user specifies after the first dot "." will be ignored by VTK. To overcome
-  // this and avoid to rewrite on input data, we are replacing the dots by dashes.
+  // this, dots are replaced by dashes.
   for(i=0;mdata[i]!='\0';i++) {
     if(mdata[i]=='.') {
       mdata[i] = '-';

--- a/src/inoutcpp_pmmg.cpp
+++ b/src/inoutcpp_pmmg.cpp
@@ -51,7 +51,7 @@ int PMMG_loadVtuMesh_centralized(PMMG_pParMesh parmesh,const char *filename) {
 
 #ifndef USE_VTK
 
-  fprintf(stderr,"  ** VTK library not founded. Unavailable file format.\n");
+  fprintf(stderr,"  ** VTK library not found. Unavailable file format.\n");
   return -1;
 
 #else
@@ -84,7 +84,7 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename) {
 
 #ifndef USE_VTK
   if ( parmesh->myrank == parmesh->info.root ) {
-    fprintf(stderr,"  ** VTK library not founded. Unavailable file format.\n");
+    fprintf(stderr,"  ** VTK library not found. Unavailable file format.\n");
   }
   return -1;
 
@@ -124,7 +124,7 @@ int PMMG_savePvtuMesh_and_allData(PMMG_pParMesh parmesh, const char * filename) 
 
 #ifndef USE_VTK
   if ( parmesh->myrank == parmesh->info.root ) {
-    fprintf(stderr,"  ** VTK library not founded. Unavailable file format.\n");
+    fprintf(stderr,"  ** VTK library not found. Unavailable file format.\n");
   }
   return -1;
 

--- a/src/inoutcpp_pmmg.cpp
+++ b/src/inoutcpp_pmmg.cpp
@@ -89,13 +89,15 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename) {
   return -1;
 
 #else
-  char* mdata=NULL; // master file name
+  char* mdata=NULL; // master    file name
+  char* sdata=NULL; // secondary file name
   MMG5_SAFE_CALLOC(mdata,strlen(filename)+6,char,return 0);
+  MMG5_SAFE_CALLOC(sdata,strlen(filename)+6,char,return 0);
 
   strcpy(mdata,filename);
   char *ptr = MMG5_Get_filenameExt(mdata);
   *ptr = '\0'; // get basename
-  snprintf( mdata,strlen(mdata), "%s.pvtu",mdata);
+  snprintf( sdata,strlen(mdata)+100, "%s.pvtu",mdata);
 
   MMG5_pMesh mesh = parmesh->listgrp[0].mesh;
   MMG5_pSol  met  = parmesh->listgrp[0].met;
@@ -106,9 +108,10 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename) {
   vtkMultiProcessController::SetGlobalController(vtkController);
 
   return MMG5_saveVtkMesh_i<vtkUnstructuredGrid,vtkXMLUnstructuredGridWriter,vtkXMLPUnstructuredGridWriter>
-    (mesh,&met,mdata,1,0,parmesh->nprocs,parmesh->myrank,parmesh->info.root);
+    (mesh,&met,sdata,1,0,parmesh->nprocs,parmesh->myrank,parmesh->info.root);
 
   MMG5_SAFE_FREE(mdata);
+  MMG5_SAFE_FREE(sdata);
 
 #endif
   return 1;
@@ -129,13 +132,15 @@ int PMMG_savePvtuMesh_and_allData(PMMG_pParMesh parmesh, const char * filename) 
   return -1;
 
 #else
-  char* mdata=NULL; // master file name
+  char* mdata=NULL; // master    file name
+  char* sdata=NULL; // secondary file name
   MMG5_SAFE_CALLOC(mdata,strlen(filename)+6,char,return 0);
+  MMG5_SAFE_CALLOC(sdata,strlen(filename)+6,char,return 0);
 
   strcpy(mdata,filename);
   char *ptr = MMG5_Get_filenameExt(mdata);
   *ptr = '\0'; // get basename
-  snprintf( mdata,strlen(mdata), "%s.pvtu",mdata);
+  snprintf( sdata,strlen(mdata), "%s.pvtu",mdata);
 
   mesh  = parmesh->listgrp[0].mesh;
   // Add met at the end of field to be able to save everything in the pvtu file
@@ -161,9 +166,10 @@ int PMMG_savePvtuMesh_and_allData(PMMG_pParMesh parmesh, const char * filename) 
   vtkMultiProcessController::SetGlobalController(vtkController);
 
   return MMG5_saveVtkMesh_i<vtkUnstructuredGrid,vtkXMLUnstructuredGridWriter,vtkXMLPUnstructuredGridWriter>
-    (mesh,allSol,mdata,metricData,0,parmesh->nprocs,parmesh->myrank,parmesh->info.root);
+    (mesh,allSol,sdata,metricData,0,parmesh->nprocs,parmesh->myrank,parmesh->info.root);
 
   MMG5_SAFE_FREE(mdata);
+  MMG5_SAFE_FREE(sdata);
 
 #endif
   return 1;

--- a/src/inoutcpp_pmmg.cpp
+++ b/src/inoutcpp_pmmg.cpp
@@ -91,12 +91,26 @@ int PMMG_savePvtuMesh(PMMG_pParMesh parmesh, const char * filename) {
 #else
   char* mdata=NULL; // master    file name
   char* sdata=NULL; // secondary file name
+  int i;
   MMG5_SAFE_CALLOC(mdata,strlen(filename)+6,char,return 0);
   MMG5_SAFE_CALLOC(sdata,strlen(filename)+6,char,return 0);
 
   strcpy(mdata,filename);
   char *ptr = MMG5_Get_filenameExt(mdata);
   *ptr = '\0'; // get basename
+
+  // If the output *.pvtu filename has dots "." in the filename,
+  // replace the dots "." with dashes "-".
+  // Why? In VTK function SetFileName(filename), the first dot "." in the
+  // filename is interpreted as the extension start. So, whatever the
+  // user specifies after the first dot "." will be ignored by VTK. To overcome
+  // this and avoid to rewrite on input data, we are replacing the dots by dashes.
+  for(i=0;mdata[i]!='\0';i++) {
+    if(mdata[i]=='.') {
+      mdata[i] = '-';
+    }
+  }
+
   snprintf( sdata,strlen(mdata)+6, "%s.pvtu",mdata);
 
   MMG5_pMesh mesh = parmesh->listgrp[0].mesh;
@@ -134,12 +148,26 @@ int PMMG_savePvtuMesh_and_allData(PMMG_pParMesh parmesh, const char * filename) 
 #else
   char* mdata=NULL; // master    file name
   char* sdata=NULL; // secondary file name
+  int i;
   MMG5_SAFE_CALLOC(mdata,strlen(filename)+6,char,return 0);
   MMG5_SAFE_CALLOC(sdata,strlen(filename)+6,char,return 0);
 
   strcpy(mdata,filename);
   char *ptr = MMG5_Get_filenameExt(mdata);
   *ptr = '\0'; // get basename
+
+  // If the output *.pvtu filename has dots "." in the filename,
+  // replace the dots "." with dashes "-".
+  // Why? In VTK function SetFileName(filename), the first dot "." in the
+  // filename is interpreted as the extension start. So, whatever the
+  // user specifies after the first dot "." will be ignored by VTK. To overcome
+  // this and avoid to rewrite on input data, we are replacing the dots by dashes.
+  for(i=0;mdata[i]!='\0';i++) {
+    if(mdata[i]=='.') {
+      mdata[i] = '-';
+    }
+  }
+
   snprintf( sdata,strlen(mdata)+6, "%s.pvtu",mdata);
 
   mesh  = parmesh->listgrp[0].mesh;

--- a/src/libparmmg_tools.c
+++ b/src/libparmmg_tools.c
@@ -501,7 +501,7 @@ int PMMG_parsar( int argc, char *argv[], PMMG_pParMesh parmesh )
   /** Step 5: Transfer options parsed by Mmg toward ParMmg (if needed) and raise
    * errors for unsupported options */
   parmesh->info.iso = parmesh->listgrp[0].mesh->info.iso;
-  parmesh->info.fem = parmesh->listgrp[0].mesh->info.fem;
+  parmesh->info.fem = parmesh->listgrp[0].mesh->info.setfem;
   parmesh->info.sethmin = parmesh->listgrp[0].mesh->info.sethmin;
   parmesh->info.sethmax = parmesh->listgrp[0].mesh->info.sethmax;
 

--- a/src/parmmg.c
+++ b/src/parmmg.c
@@ -385,33 +385,34 @@ check_mesh_loading:
       char *basename = MMG5_Remove_ext ( parmesh->meshout,".mesh" );
       fprintf(stdout,"\n  -- WRITING DATA FILE %s.<rankid>.mesh\n",basename);
       MMG5_SAFE_FREE ( basename );
-      if (grp->field) {
-        fprintf(stdout,"       Writing mesh, metric and fields.\n");
-      }
-      else {
-        fprintf(stdout,"       Writing mesh and metric.\n");
-      }
     }
     else if ( parmesh->info.fmtout == PMMG_FMT_DistributedMeditBinary ) {
       char *basename = MMG5_Remove_ext ( parmesh->meshout,".meshb" );
       fprintf(stdout,"\n  -- WRITING DATA FILE %s.<rankid>.meshb\n",basename);
       MMG5_SAFE_FREE ( basename );
-      if (grp->field) {
-        fprintf(stdout,"       Writing mesh, metric and fields.\n");
+    }
+    else if ( parmesh->info.fmtout == MMG5_FMT_VtkPvtu ) {
+      char *basename = MMG5_Remove_ext ( parmesh->meshout,".pvtu" );
+      int i, rename=0;
+      for(i=0;basename[i]!='\0';i++) {
+        if(basename[i]=='.') {
+          basename[i] = '-';
+          rename = 1;
+        }
       }
-      else {
-        fprintf(stdout,"       Writing mesh and metric.\n");
-      }
+      fprintf(stdout,"\n  -- WRITING DATA FILES %s.pvtu\n",basename);
+      if (rename) fprintf(stdout,"       ## WARNING: Filename has been changed: "
+              "%s => %s.pvtu\n",parmesh->meshout,basename);
+      MMG5_SAFE_FREE ( basename );
     }
     else {
-      if (grp->field) {
-        fprintf(stdout,"\n  -- WRITING DATA FILE %s\n"
-                "       Writing mesh, metric and fields.\n",parmesh->meshout);
-      }
-      else {
-        fprintf(stdout,"\n  -- WRITING DATA FILE %s\n"
-                "       Writing mesh and metric.\n",parmesh->meshout);
-      }
+      fprintf(stdout,"\n  -- WRITING DATA FILE %s\n",parmesh->meshout);
+    }
+    if (grp->field) {
+      fprintf(stdout,"       Writing mesh, metric and fields.\n");
+    }
+    else {
+      fprintf(stdout,"       Writing mesh and metric.\n");
     }
   }
 


### PR DESCRIPTION
1. In `inoutcpp_pmmg.c` file: Fix bug in `snprintf` in `PMMG_savePvtuMesh` and `PMMG_savePvtuMesh_and_allData`. `snprintf` cannot support to have input and output filename using the same variable. Use an intermediate filename to overcome this issue.
2. Fix typo in `inoutcpp_pmmg.c` file: `founded` -> `found` + update regex in accordance in `cmake/testing/pmmg_tests.cmake`.
3. For output file at `*.pvtu` format: 
    - In `inoutcpp_pmmg.c` file: if the output filename has dots "." in the basename, replace them with dashes "-". Why? In VTK function SetFileName(filename), the first dot "." in the filename is interpreted as the extension start. So, whatever the user specifies after the first dot "." will be ignored by VTK. To overcome this, dots are replaced by dashes. 
    - In `parmmg.c` file: a warning is displayed to the user if the basename is changed.
    - In `cmake/testing/pmmg_tests.cmake`: Add test to check if the basename is well modified in this case.