### PR TITLE
Update point tag with MG_REF if the edge in xtetra is MG_REF + ci tests associated

### DIFF
--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -21,7 +21,7 @@ IF( BUILD_TESTING )
       ENDIF()
       EXECUTE_PROCESS(
         COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} fetch
-        COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} checkout c60fb6a16a7fcbc3e93d9b2babd6cb19caba8123
+        COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} checkout b3fece6cb6afbcd73962c7586aafa211af396e4c
         TIMEOUT 20
         WORKING_DIRECTORY ${CI_DIR}
         #COMMAND_ECHO STDOUT
@@ -224,7 +224,7 @@ IF( BUILD_TESTING )
 
     add_test( NAME PvtuOut-RenameOut-2
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
       -out ${CI_DIR_RESULTS}/3D-cube-PvtuOut-2.a.o.pvtu)
 
     set_property(TEST PvtuOut-RenameOut-2
@@ -342,9 +342,9 @@ IF( BUILD_TESTING )
   foreach( NP 1 2 4 8 )
     add_test( NAME ls-CenIn-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
       -ls 0.0
-      -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
+      -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
       -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-${NP}.o.mesh)
   endforeach()
 
@@ -356,9 +356,9 @@ IF( BUILD_TESTING )
   foreach( NP 1 2)
     add_test( NAME ls-arg-option-openlsfile-lsval-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
       -ls 0.0
-      -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
+      -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
       -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-lsval-${NP}.o.mesh)
     set_property(TEST ls-arg-option-openlsfile-lsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
@@ -368,9 +368,9 @@ IF( BUILD_TESTING )
   foreach( NP 1 2)
     add_test( NAME ls-arg-option-openlsfile-nolsval-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
       -ls
-      -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
+      -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
       -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-nolsval-${NP}.o.mesh)
     set_property(TEST ls-arg-option-openlsfile-nolsval-${NP}
       PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
@@ -380,7 +380,7 @@ IF( BUILD_TESTING )
   foreach( NP 1 2)
     add_test( NAME ls-arg-option-openlsfiledefault-lsval-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
       -ls 0.0
       -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-lsval-${NP}.o.mesh)
     set_property(TEST ls-arg-option-openlsfiledefault-lsval-${NP}
@@ -391,7 +391,7 @@ IF( BUILD_TESTING )
   foreach( NP 1 2)
     add_test( NAME ls-arg-option-openlsfiledefault-nolsval-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
       -ls
       -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-nolsval-${NP}.o.mesh)
     set_property(TEST ls-arg-option-openlsfiledefault-nolsval-${NP}
@@ -402,10 +402,10 @@ IF( BUILD_TESTING )
   foreach( NP 1 2 4 8 )
   add_test( NAME ls-CenIn-met-${NP}
     COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+    ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
     -ls 0.0
-    -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
-    -met ${CI_DIR}/LevelSet/centralized/3D-cube-metric.sol
+    -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
+    -met ${CI_DIR}/LevelSet/1p_centralized/3D-cube-metric.sol
     -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-met-${NP}.o.mesh)
   endforeach()
 
@@ -413,9 +413,9 @@ IF( BUILD_TESTING )
   foreach( NP 1 2 4 8 )
     add_test( NAME ls-CenIn-DisOut-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/centralized/3D-cube.mesh
+      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
       -ls 0.0
-      -sol ${CI_DIR}/LevelSet/centralized/3D-cube-ls.sol
+      -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
       -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-DisOut-${NP}-out.pvtu)
 
     IF ( (NOT VTK_FOUND) OR USE_VTK MATCHES OFF )
@@ -430,9 +430,9 @@ IF( BUILD_TESTING )
   #--------------------------------
   add_test( NAME ls-DisIn-ReadLs-2
     COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/LevelSet/distributed/3D-cube.mesh -v 10
+    ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh -v 10
     -ls 0.01
-    -sol ${CI_DIR}/LevelSet/distributed/3D-cube-ls.sol
+    -sol ${CI_DIR}/LevelSet/2p_distributed/3D-cube-ls.sol
     -out ${CI_DIR_RESULTS}/ls-DisIn-ReadLs-2.o.mesh)
   set(lsReadFile "3D-cube-ls.0.sol OPENED")
   set_property(TEST ls-DisIn-ReadLs-2
@@ -525,8 +525,8 @@ IF( BUILD_TESTING )
   # and  to write distributed output fields in VTK   format
   add_test( NAME fields-DisIn-DisOutVTK-2
     COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/LevelSet/distributed/3D-cube.mesh -v 10
-    -field ${CI_DIR}/LevelSet/distributed/3D-cube-fields.sol
+    ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh -v 10
+    -field ${CI_DIR}/LevelSet/2p_distributed/3D-cube-fields.sol
     -out ${CI_DIR_RESULTS}/3D-cube-fields-DisIn-DisOutVTK-2-out.pvtu)
 
   set(InputDistributedFields "3D-cube-fields.0.sol OPENED")
@@ -540,8 +540,8 @@ IF( BUILD_TESTING )
   # Test to write distributed output fields and metric in Medit format
   add_test( NAME fields-DisIn-DisOutMesh-2
     COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/LevelSet/distributed/3D-cube.mesh
-    -field ${CI_DIR}/LevelSet/distributed/3D-cube-fields.sol
+    ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh
+    -field ${CI_DIR}/LevelSet/2p_distributed/3D-cube-fields.sol
     -out ${CI_DIR_RESULTS}/3D-cube-fields-DisIn-DisOutMesh-2.o.mesh)
 
   set(OutputFieldsName "3D-cube-fields.o.0.sol OPENED.")

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -328,6 +328,14 @@ IF( BUILD_TESTING )
       ENDFOREACH()
     ENDFOREACH()
 
+    # Test to verify the patch on update MG_REF tag.
+    # This test fail if the tag MG_REF is not updated by PMMG_updateTagRef_node in PMMG_update_analys.
+    # See ParMmg PR#
+    add_test( NAME update-ref-tag
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/2p_toygeom/cube-distributed-faces-nomat-1edge.mesh -v 10 -hsiz 0.1
+      -out ${CI_DIR_RESULTS}/update-ref-tag.o.mesh)
+
     ###############################################################################
     #####
     #####        Test isovalue mode - ls discretization

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -328,240 +328,240 @@ IF( BUILD_TESTING )
       ENDFOREACH()
     ENDFOREACH()
 
-  ENDIF()
+    ###############################################################################
+    #####
+    #####        Test isovalue mode - ls discretization
+    #####
+    ###############################################################################
+    #--------------------------------
+    #--- CENTRALIZED INPUT (CenIn)
+    #--------------------------------
+    # Tests of ls discretization for centralized mesh input
+    foreach( NP 1 2 4 8 )
+      add_test( NAME ls-CenIn-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
+        -ls 0.0
+        -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
+        -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-${NP}.o.mesh)
+    endforeach()
 
-  ###############################################################################
-  #####
-  #####        Test isovalue mode - ls discretization
-  #####
-  ###############################################################################
-  #--------------------------------
-  #--- CENTRALIZED INPUT (CenIn)
-  #--------------------------------
-  # Tests of ls discretization for centralized mesh input
-  foreach( NP 1 2 4 8 )
-    add_test( NAME ls-CenIn-${NP}
+    # Check that the ls file is correctly opened with or without the ls value given
+    set(lsOpenFile "3D-cube-ls.sol OPENED")
+    set(lsOpenFileDefault "3D-cube.sol  NOT FOUND. USE DEFAULT METRIC.")
+
+    # Test of opening ls file when ls val is given
+    foreach( NP 1 2)
+      add_test( NAME ls-arg-option-openlsfile-lsval-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
+        -ls 0.0
+        -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
+        -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-lsval-${NP}.o.mesh)
+      set_property(TEST ls-arg-option-openlsfile-lsval-${NP}
+        PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
+    endforeach()
+
+    # Test of opening ls file when ls val is not given
+    foreach( NP 1 2)
+      add_test( NAME ls-arg-option-openlsfile-nolsval-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
+        -ls
+        -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
+        -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-nolsval-${NP}.o.mesh)
+      set_property(TEST ls-arg-option-openlsfile-nolsval-${NP}
+        PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
+    endforeach()
+
+    # Test of opening ls file with a default name when ls val is given
+    foreach( NP 1 2)
+      add_test( NAME ls-arg-option-openlsfiledefault-lsval-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
+        -ls 0.0
+        -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-lsval-${NP}.o.mesh)
+      set_property(TEST ls-arg-option-openlsfiledefault-lsval-${NP}
+        PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
+    endforeach()
+
+    # Test of opening ls file with a default name when ls val is not given
+    foreach( NP 1 2)
+      add_test( NAME ls-arg-option-openlsfiledefault-nolsval-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
+        -ls
+        -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-nolsval-${NP}.o.mesh)
+      set_property(TEST ls-arg-option-openlsfiledefault-nolsval-${NP}
+        PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
+    endforeach()
+
+    # Tests for ls + met for centralized mesh input
+    foreach( NP 1 2 4 8 )
+    add_test( NAME ls-CenIn-met-${NP}
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
       -ls 0.0
       -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-${NP}.o.mesh)
-  endforeach()
+      -met ${CI_DIR}/LevelSet/1p_centralized/3D-cube-metric.sol
+      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-met-${NP}.o.mesh)
+    endforeach()
 
-  # Check that the ls file is correctly opened with or without the ls value given
-  set(lsOpenFile "3D-cube-ls.sol OPENED")
-  set(lsOpenFileDefault "3D-cube.sol  NOT FOUND. USE DEFAULT METRIC.")
+    # Tests of distributed pvtu output when ls mode
+    foreach( NP 1 2 4 8 )
+      add_test( NAME ls-CenIn-DisOut-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
+        -ls 0.0
+        -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
+        -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-DisOut-${NP}-out.pvtu)
 
-  # Test of opening ls file when ls val is given
-  foreach( NP 1 2)
-    add_test( NAME ls-arg-option-openlsfile-lsval-${NP}
-      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
-      -ls 0.0
-      -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-lsval-${NP}.o.mesh)
-    set_property(TEST ls-arg-option-openlsfile-lsval-${NP}
-      PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
-  endforeach()
+      IF ( (NOT VTK_FOUND) OR USE_VTK MATCHES OFF )
+        set_property(TEST ls-CenIn-DisOut-${NP}
+          PROPERTY PASS_REGULAR_EXPRESSION "${OutputVtkErr}")
+      ENDIF ( )
 
-  # Test of opening ls file when ls val is not given
-  foreach( NP 1 2)
-    add_test( NAME ls-arg-option-openlsfile-nolsval-${NP}
-      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
-      -ls
-      -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfile-nolsval-${NP}.o.mesh)
-    set_property(TEST ls-arg-option-openlsfile-nolsval-${NP}
-      PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFile}")
-  endforeach()
+    endforeach()
 
-  # Test of opening ls file with a default name when ls val is given
-  foreach( NP 1 2)
-    add_test( NAME ls-arg-option-openlsfiledefault-lsval-${NP}
-      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
-      -ls 0.0
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-lsval-${NP}.o.mesh)
-    set_property(TEST ls-arg-option-openlsfiledefault-lsval-${NP}
-      PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
-  endforeach()
+    #--------------------------------
+    #--- DISTRIBUTED INPUT (DisIn)
+    #--------------------------------
+    add_test( NAME ls-DisIn-ReadLs-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh -v 10
+      -ls 0.01
+      -sol ${CI_DIR}/LevelSet/2p_distributed/3D-cube-ls.sol
+      -out ${CI_DIR_RESULTS}/ls-DisIn-ReadLs-2.o.mesh)
+    set(lsReadFile "3D-cube-ls.0.sol OPENED")
+    set_property(TEST ls-DisIn-ReadLs-2
+      PROPERTY PASS_REGULAR_EXPRESSION "${lsReadFile}")
 
-  # Test of opening ls file with a default name when ls val is not given
-  foreach( NP 1 2)
-    add_test( NAME ls-arg-option-openlsfiledefault-nolsval-${NP}
-      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
-      -ls
-      -out ${CI_DIR_RESULTS}/ls-arg-option-openlsfiledefault-nolsval-${NP}.o.mesh)
-    set_property(TEST ls-arg-option-openlsfiledefault-nolsval-${NP}
-      PROPERTY PASS_REGULAR_EXPRESSION "${lsOpenFileDefault}")
-  endforeach()
+    # Test Medit and hdf5 distributed inputs, with npartin < npart or npartin ==
+    # npart with mesh only or mesh+metric.
 
-  # Tests for ls + met for centralized mesh input
-  foreach( NP 1 2 4 8 )
-  add_test( NAME ls-CenIn-met-${NP}
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
-    -ls 0.0
-    -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
-    -met ${CI_DIR}/LevelSet/1p_centralized/3D-cube-metric.sol
-    -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-met-${NP}.o.mesh)
-  endforeach()
+    ## Medit distributed with npart = 2 and  npartin = 1, only mesh and hdf5 output using .h5 ext
+    add_test( NAME Medit-DisIn-MeshOnly-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Parallel_IO/Medit/1p/cube-unit-coarse.mesh -v 5
+      -out ${CI_DIR_RESULTS}/Medit-DisIn-MeshOnly-2.o.h5)
 
-  # Tests of distributed pvtu output when ls mode
-  foreach( NP 1 2 4 8 )
-    add_test( NAME ls-CenIn-DisOut-${NP}
-      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
-      ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh
-      -ls 0.0
-      -sol ${CI_DIR}/LevelSet/1p_centralized/3D-cube-ls.sol
-      -out ${CI_DIR_RESULTS}/3D-cube-ls-CenIn-DisOut-${NP}-out.pvtu)
+    ## Medit distributed with npart = 2 and  npartin = 1, mesh+met and hdf5 output using .xdmf ext
+    add_test( NAME Medit-DisIn-MeshAndMet-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      -in ${CI_DIR}/Parallel_IO/Medit/1p/cube-unit-coarse-with-met -v 5
+      -out ${CI_DIR_RESULTS}/Medit-DisIn-MeshAndMet-2.o.xdmf)
 
-    IF ( (NOT VTK_FOUND) OR USE_VTK MATCHES OFF )
-      set_property(TEST ls-CenIn-DisOut-${NP}
-        PROPERTY PASS_REGULAR_EXPRESSION "${OutputVtkErr}")
+    ## Medit distributed with npart = 4 and  npartin = 4, only mesh .h5 ext
+    add_test( NAME Medit-DisIn-MeshOnly-4
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      -in ${CI_DIR}/Parallel_IO/Medit/4p/cube-unit-coarse.mesh -v 5
+      ${CI_DIR_RESULTS}/Medit-DisIn-MeshOnly-4.o.h5)
+
+    ## Medit distributed with npart = 6 and  npartin = 4, only mesh .xdmf ext
+    add_test( NAME Medit-DisIn-MeshOnly-6
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 6 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Parallel_IO/Medit/4p/cube-unit-coarse -v 5
+      ${CI_DIR_RESULTS}/Medit-DisIn-MeshOnly-6.o.xdmf)
+
+    ## hdf5 distributed with npart = 2 and  npartin = 1, only mesh and h5 output
+    add_test( NAME hdf5-DisIn-MeshOnly-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Parallel_IO/hdf5/1p/cube-unit-coarse.h5 -v 5
+      -out ${CI_DIR_RESULTS}/hdf5-DisIn-MeshOnly-2.o.h5)
+
+    ## hdf5 distributed with npart = 2 and  npartin = 1, mesh+met and xdmf (h5) output
+    add_test( NAME hdf5-DisIn-MeshAndMet-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Parallel_IO/hdf5/1p/cube-unit-coarse-with-met.h5 -v 5
+      -out ${CI_DIR_RESULTS}/hdf5-DisIn-MeshAndMet-2.o.xdmf)
+
+    ## hdf5 distributed with npart = 8 and  npartin = 4, mesh+met and h5 output
+    add_test( NAME hdf5-DisIn-MeshAndMet-8
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 8 $<TARGET_FILE:${PROJECT_NAME}>
+      -in ${CI_DIR}/Parallel_IO/hdf5/4p/cube-unit-coarse-with-met.h5 -v 5
+      ${CI_DIR_RESULTS}/hdf5-DisIn-MeshAndMet-8.o.h5)
+
+    ## hdf5 distributed with npart = 8 and  npartin = 4, mesh only and medit centralized output
+    add_test( NAME hdf5-DisIn-MeshOnly-8
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 8 $<TARGET_FILE:${PROJECT_NAME}>
+      -in ${CI_DIR}/Parallel_IO/hdf5/4p/cube-unit-coarse.h5 -v 5 -centralized-output
+      -out ${CI_DIR_RESULTS}/hdf5-DisIn-MeshOnly-8.o.mesh)
+
+    ## hdf5 distributed with npart = 4 and  npartin = 4, mesh+met and h5 output
+    add_test( NAME hdf5-DisIn-MeshAndMet-4
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      -in ${CI_DIR}/Parallel_IO/hdf5/4p/cube-unit-coarse-with-met.h5 -v 5
+      ${CI_DIR_RESULTS}/hdf5-DisIn-MeshAndMet-8.o.h5)
+
+    ## hdf5 distributed with npart = 4 and  npartin = 4, mesh only and medit centralized output
+    add_test( NAME hdf5-DisIn-MeshOnly-4
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      -in ${CI_DIR}/Parallel_IO/hdf5/4p/cube-unit-coarse.h5 -v 5 -centralized-output
+      -out ${CI_DIR_RESULTS}/hdf5-DisIn-MeshOnly-8.o.mesh)
+
+
+    IF ( (NOT HDF5_FOUND) OR USE_HDF5 MATCHES OFF )
+      SET(expr "HDF5 library not found")
+      SET_PROPERTY(
+        TEST Medit-DisIn-MeshOnly-2 Medit-DisIn-MeshAndMet-2 Medit-DisIn-MeshOnly-4
+        Medit-DisIn-MeshOnly-6 hdf5-DisIn-MeshOnly-2 hdf5-DisIn-MeshAndMet-2
+        hdf5-DisIn-MeshAndMet-8  hdf5-DisIn-MeshOnly-8
+        hdf5-DisIn-MeshAndMet-4  hdf5-DisIn-MeshOnly-4
+        PROPERTY PASS_REGULAR_EXPRESSION "${expr}")
     ENDIF ( )
 
-  endforeach()
 
-  #--------------------------------
-  #--- DISTRIBUTED INPUT (DisIn)
-  #--------------------------------
-  add_test( NAME ls-DisIn-ReadLs-2
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh -v 10
-    -ls 0.01
-    -sol ${CI_DIR}/LevelSet/2p_distributed/3D-cube-ls.sol
-    -out ${CI_DIR_RESULTS}/ls-DisIn-ReadLs-2.o.mesh)
-  set(lsReadFile "3D-cube-ls.0.sol OPENED")
-  set_property(TEST ls-DisIn-ReadLs-2
-    PROPERTY PASS_REGULAR_EXPRESSION "${lsReadFile}")
+    ###############################################################################
+    #####
+    #####        Test with fields input and output
+    #####
+    ###############################################################################
+    #--------------------------------
+    #--- DISTRIBUTED INPUT (DisIn)
+    #--------------------------------
+    # Test to read  distributed input  fields in Medit format
+    # and  to write distributed output fields in VTK   format
+    add_test( NAME fields-DisIn-DisOutVTK-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh -v 10
+      -field ${CI_DIR}/LevelSet/2p_distributed/3D-cube-fields.sol
+      -out ${CI_DIR_RESULTS}/3D-cube-fields-DisIn-DisOutVTK-2-out.pvtu)
 
-  # Test Medit and hdf5 distributed inputs, with npartin < npart or npartin ==
-  # npart with mesh only or mesh+metric.
+    set(InputDistributedFields "3D-cube-fields.0.sol OPENED")
+    set(OutputVtkFields "Writing mesh, metric and fields.")
 
-  ## Medit distributed with npart = 2 and  npartin = 1, only mesh and hdf5 output using .h5 ext
-  add_test( NAME Medit-DisIn-MeshOnly-2
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/Parallel_IO/Medit/1p/cube-unit-coarse.mesh -v 5
-    -out ${CI_DIR_RESULTS}/Medit-DisIn-MeshOnly-2.o.h5)
+    set_property(TEST fields-DisIn-DisOutVTK-2
+      PROPERTY PASS_REGULAR_EXPRESSION
+      "${InputDistributedFields}.*${OutputVtkFields};
+      ${OutputVtkFields}.*${InputDistributedFields}")
 
-  ## Medit distributed with npart = 2 and  npartin = 1, mesh+met and hdf5 output using .xdmf ext
-  add_test( NAME Medit-DisIn-MeshAndMet-2
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    -in ${CI_DIR}/Parallel_IO/Medit/1p/cube-unit-coarse-with-met -v 5
-    -out ${CI_DIR_RESULTS}/Medit-DisIn-MeshAndMet-2.o.xdmf)
+    # Test to write distributed output fields and metric in Medit format
+    add_test( NAME fields-DisIn-DisOutMesh-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh
+      -field ${CI_DIR}/LevelSet/2p_distributed/3D-cube-fields.sol
+      -out ${CI_DIR_RESULTS}/3D-cube-fields-DisIn-DisOutMesh-2.o.mesh)
 
-  ## Medit distributed with npart = 4 and  npartin = 4, only mesh .h5 ext
-  add_test( NAME Medit-DisIn-MeshOnly-4
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
-    -in ${CI_DIR}/Parallel_IO/Medit/4p/cube-unit-coarse.mesh -v 5
-    ${CI_DIR_RESULTS}/Medit-DisIn-MeshOnly-4.o.h5)
+    set(OutputFieldsName "3D-cube-fields.o.0.sol OPENED.")
+    set(OutputMetricName "3D-cube-fields-DisIn-DisOutMesh-2.o.0.sol OPENED.")
+    set_property(TEST fields-DisIn-DisOutMesh-2
+      PROPERTY PASS_REGULAR_EXPRESSION
+      "${OutputFieldsName}.*${OutputMetricName};${OutputMetricName}.*${OutputFieldsName}")
 
-  ## Medit distributed with npart = 6 and  npartin = 4, only mesh .xdmf ext
-  add_test( NAME Medit-DisIn-MeshOnly-6
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 6 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/Parallel_IO/Medit/4p/cube-unit-coarse -v 5
-    ${CI_DIR_RESULTS}/Medit-DisIn-MeshOnly-6.o.xdmf)
+    # Test saving of solution fields on 4 procs at hdf5 format
+    add_test( NAME hdf5-CenIn-DisOutHdf5-4
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Interpolation/coarse.meshb -v 5
+      -out ${CI_DIR_RESULTS}/hdf5-CenIn-DisOutHdf5-4.o.h5)
 
-  ## hdf5 distributed with npart = 2 and  npartin = 1, only mesh and h5 output
-  add_test( NAME hdf5-DisIn-MeshOnly-2
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/Parallel_IO/hdf5/1p/cube-unit-coarse.h5 -v 5
-    -out ${CI_DIR_RESULTS}/hdf5-DisIn-MeshOnly-2.o.h5)
+    IF ( (NOT HDF5_FOUND) OR USE_HDF5 MATCHES OFF )
+      SET(expr "HDF5 library not found")
+      SET_PROPERTY(
+        TEST hdf5-CenIn-DisOutHdf5-4
+        PROPERTY PASS_REGULAR_EXPRESSION "${expr}")
+    ENDIF ( )
 
-  ## hdf5 distributed with npart = 2 and  npartin = 1, mesh+met and xdmf (h5) output
-  add_test( NAME hdf5-DisIn-MeshAndMet-2
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/Parallel_IO/hdf5/1p/cube-unit-coarse-with-met.h5 -v 5
-    -out ${CI_DIR_RESULTS}/hdf5-DisIn-MeshAndMet-2.o.xdmf)
-
-  ## hdf5 distributed with npart = 8 and  npartin = 4, mesh+met and h5 output
-  add_test( NAME hdf5-DisIn-MeshAndMet-8
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 8 $<TARGET_FILE:${PROJECT_NAME}>
-    -in ${CI_DIR}/Parallel_IO/hdf5/4p/cube-unit-coarse-with-met.h5 -v 5
-    ${CI_DIR_RESULTS}/hdf5-DisIn-MeshAndMet-8.o.h5)
-
-  ## hdf5 distributed with npart = 8 and  npartin = 4, mesh only and medit centralized output
-  add_test( NAME hdf5-DisIn-MeshOnly-8
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 8 $<TARGET_FILE:${PROJECT_NAME}>
-    -in ${CI_DIR}/Parallel_IO/hdf5/4p/cube-unit-coarse.h5 -v 5 -centralized-output
-    -out ${CI_DIR_RESULTS}/hdf5-DisIn-MeshOnly-8.o.mesh)
-
-  ## hdf5 distributed with npart = 4 and  npartin = 4, mesh+met and h5 output
-  add_test( NAME hdf5-DisIn-MeshAndMet-4
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
-    -in ${CI_DIR}/Parallel_IO/hdf5/4p/cube-unit-coarse-with-met.h5 -v 5
-    ${CI_DIR_RESULTS}/hdf5-DisIn-MeshAndMet-8.o.h5)
-
-  ## hdf5 distributed with npart = 4 and  npartin = 4, mesh only and medit centralized output
-  add_test( NAME hdf5-DisIn-MeshOnly-4
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
-    -in ${CI_DIR}/Parallel_IO/hdf5/4p/cube-unit-coarse.h5 -v 5 -centralized-output
-    -out ${CI_DIR_RESULTS}/hdf5-DisIn-MeshOnly-8.o.mesh)
-
-
-  IF ( (NOT HDF5_FOUND) OR USE_HDF5 MATCHES OFF )
-    SET(expr "HDF5 library not found")
-    SET_PROPERTY(
-      TEST Medit-DisIn-MeshOnly-2 Medit-DisIn-MeshAndMet-2 Medit-DisIn-MeshOnly-4
-      Medit-DisIn-MeshOnly-6 hdf5-DisIn-MeshOnly-2 hdf5-DisIn-MeshAndMet-2
-      hdf5-DisIn-MeshAndMet-8  hdf5-DisIn-MeshOnly-8
-      hdf5-DisIn-MeshAndMet-4  hdf5-DisIn-MeshOnly-4
-      PROPERTY PASS_REGULAR_EXPRESSION "${expr}")
-  ENDIF ( )
-
-
-  ###############################################################################
-  #####
-  #####        Test with fields input and output
-  #####
-  ###############################################################################
-  #--------------------------------
-  #--- DISTRIBUTED INPUT (DisIn)
-  #--------------------------------
-  # Test to read  distributed input  fields in Medit format
-  # and  to write distributed output fields in VTK   format
-  add_test( NAME fields-DisIn-DisOutVTK-2
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh -v 10
-    -field ${CI_DIR}/LevelSet/2p_distributed/3D-cube-fields.sol
-    -out ${CI_DIR_RESULTS}/3D-cube-fields-DisIn-DisOutVTK-2-out.pvtu)
-
-  set(InputDistributedFields "3D-cube-fields.0.sol OPENED")
-  set(OutputVtkFields "Writing mesh, metric and fields.")
-
-  set_property(TEST fields-DisIn-DisOutVTK-2
-    PROPERTY PASS_REGULAR_EXPRESSION
-    "${InputDistributedFields}.*${OutputVtkFields};
-     ${OutputVtkFields}.*${InputDistributedFields}")
-
-  # Test to write distributed output fields and metric in Medit format
-  add_test( NAME fields-DisIn-DisOutMesh-2
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/LevelSet/2p_distributed/3D-cube.mesh
-    -field ${CI_DIR}/LevelSet/2p_distributed/3D-cube-fields.sol
-    -out ${CI_DIR_RESULTS}/3D-cube-fields-DisIn-DisOutMesh-2.o.mesh)
-
-  set(OutputFieldsName "3D-cube-fields.o.0.sol OPENED.")
-  set(OutputMetricName "3D-cube-fields-DisIn-DisOutMesh-2.o.0.sol OPENED.")
-  set_property(TEST fields-DisIn-DisOutMesh-2
-    PROPERTY PASS_REGULAR_EXPRESSION
-    "${OutputFieldsName}.*${OutputMetricName};${OutputMetricName}.*${OutputFieldsName}")
-
-  # Test saving of solution fields on 4 procs at hdf5 format
-  add_test( NAME hdf5-CenIn-DisOutHdf5-4
-    COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
-    ${CI_DIR}/Interpolation/coarse.meshb -v 5
-    -out ${CI_DIR_RESULTS}/hdf5-CenIn-DisOutHdf5-4.o.h5)
-
-  IF ( (NOT HDF5_FOUND) OR USE_HDF5 MATCHES OFF )
-    SET(expr "HDF5 library not found")
-    SET_PROPERTY(
-      TEST hdf5-CenIn-DisOutHdf5-4
-      PROPERTY PASS_REGULAR_EXPRESSION "${expr}")
-  ENDIF ( )
+  ENDIF()
 
   ###############################################################################
   #####

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -330,7 +330,7 @@ IF( BUILD_TESTING )
 
     # Test to verify the patch on update MG_REF tag.
     # This test fail if the tag MG_REF is not updated by PMMG_updateTagRef_node in PMMG_update_analys.
-    # See ParMmg PR#
+    # See ParMmg PR#103
     add_test( NAME update-ref-tag
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/LevelSet/2p_toygeom/cube-distributed-faces-nomat-1edge.mesh -v 10 -hsiz 0.1

--- a/src/analys_pmmg.c
+++ b/src/analys_pmmg.c
@@ -1568,6 +1568,9 @@ int PMMG_update_analys(PMMG_pParMesh parmesh) {
       return 0;
     }
 
+    /* Update tag MG_REF of points if edge tag is MG_REF in xtetra */
+    PMMG_updateTagRef_node(parmesh,mesh);
+
     /* First: seek edges at the interface of two distinct domains and mark it as
      * required */
 #warning Luca: add a function like MMG5_setEdgeNmTag(mesh,hash)

--- a/src/parmmg.h
+++ b/src/parmmg.h
@@ -527,6 +527,7 @@ void PMMG_untag_par_edge(MMG5_pxTetra pxt,int j);
 void PMMG_untag_par_face(MMG5_pxTetra pxt,int j);
 int  PMMG_resetOldTag(PMMG_pParMesh parmesh);
 int  PMMG_updateTag(PMMG_pParMesh parmesh);
+void PMMG_updateTagRef_node(PMMG_pParMesh parmesh,MMG5_pMesh mesh);
 int  PMMG_parbdySet( PMMG_pParMesh parmesh );
 int  PMMG_parbdyTria( PMMG_pParMesh parmesh );
 

--- a/src/tag_pmmg.c
+++ b/src/tag_pmmg.c
@@ -458,6 +458,9 @@ int PMMG_updateTag(PMMG_pParMesh parmesh) {
  * \param mesh pointer to the mesh structure
  *
  * Update the nodes tag with MG_REF if the edge in tetra is also MG_REF
+ * \remark When we enter this function, the tag MG_OLDPBDY is correctly assigned to xtetra.ftag only.
+ * However, we can have only an edge on the // interface (and no face). Therefore, we need 
+ * to loop over all the edges of all the tetra.
  *
  */
 void PMMG_updateTagRef_node(PMMG_pParMesh parmesh, MMG5_pMesh mesh) {

--- a/src/tag_pmmg.c
+++ b/src/tag_pmmg.c
@@ -454,6 +454,39 @@ int PMMG_updateTag(PMMG_pParMesh parmesh) {
 }
 
 /**
+ * \param parmesh pointer toward the parmesh structure.
+ * \param mesh pointer to the mesh structure
+ *
+ * Update the nodes tag with MG_REF if the edge in tetra is also MG_REF
+ *
+ */
+void PMMG_updateTagRef_node(PMMG_pParMesh parmesh, MMG5_pMesh mesh) {
+  MMG5_pTetra   pt;
+  MMG5_pxTetra  pxt;
+  MMG5_int      k,ip0,ip1;
+  int           ia;
+
+  for ( k=1; k<=mesh->ne; k++ ) {
+    pt = &mesh->tetra[k];
+    if ( !MG_EOK(pt) ) continue;
+    if ( !pt->xt ) continue;
+    pxt = &mesh->xtetra[pt->xt];
+    for ( ia=0 ; ia<6 ; ia++ ) {
+      if ( pxt->tag[ia] & MG_REF) {
+        ip0 = pt->v[MMG5_iare[ia][0]];
+        ip1 = pt->v[MMG5_iare[ia][1]];
+        if ( !(mesh->point[ip0].tag & MG_REF) ) {
+          mesh->point[ip0].tag |= MG_REF;
+        }
+        if ( !(mesh->point[ip1].tag & MG_REF) ) {
+          mesh->point[ip1].tag |= MG_REF;
+        }
+      }
+    }
+  }
+}
+
+/**
  * \param parmesh pointer to parmesh structure.
  * \return 0 if fail, 1 if success.
  *


### PR DESCRIPTION
**Update the point tag with `MG_REF` if the edge in xtetra is `MG_REF` in the analysis update.** 
After load balancing, the analysis need to be updated (`PMMG_update_analys`), in particular, the point tag might not be up to date regarding the tag `MG_REF`. Indeed, if in the input distributed meshes one `Edge` is also a `ParallelEdge`, the tag `MG_REF` to the point is not assigned properly by the analysis because parallel interfaces are systematically skipped (for example, see condition  `if(((pt->tag[i] & MG_PARBDY) && !(pt->tag[i] & MG_PARBDYBDY)) || (pt->tag[i] & MG_BDY) ) continue;` in `MMG5_setadj`). This is not an issue in the first iteration, however after the load balancing and in the second iteration, point tags need to be up to date. To do so, the function `PMMG_updateTagRef_node` is now added when the analysis is updated.

**CI tests**
1. Add ci test for the update of the point tag with tag `MG_REF`
2. Update testparmmg git tag to point towards the latest master version
3. Update ci tests regarding the latest reorganization of testparmmg folder
4. Include LS and field ci test in the `IF ( NOT ONLY_LIBRARY_TESTS )`

