### PR TITLE
Copy mesh information of local parameters or LS reference (multimat)

### DIFF
--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -21,7 +21,7 @@ IF( BUILD_TESTING )
       ENDIF()
       EXECUTE_PROCESS(
         COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} fetch
-        COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} checkout b23b5cfe1b3e57b25a16befcc08cdb7f32178d75
+        COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} checkout 89cdf876d577ca5c26767decac4fc35e4ae0d255
         TIMEOUT 20
         WORKING_DIRECTORY ${CI_DIR}
         #COMMAND_ECHO STDOUT

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -21,7 +21,7 @@ IF( BUILD_TESTING )
       ENDIF()
       EXECUTE_PROCESS(
         COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} fetch
-        COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} checkout b3fece6cb6afbcd73962c7586aafa211af396e4c
+        COMMAND ${GIT_EXECUTABLE} -C ${CI_DIR} checkout b23b5cfe1b3e57b25a16befcc08cdb7f32178d75
         TIMEOUT 20
         WORKING_DIRECTORY ${CI_DIR}
         #COMMAND_ECHO STDOUT
@@ -518,6 +518,67 @@ IF( BUILD_TESTING )
         PROPERTY PASS_REGULAR_EXPRESSION "${expr}")
     ENDIF ( )
 
+   ###############################################################################
+    #####
+    #####        Test with multi-material input file *mmg3d 'LSReferences'
+    #####
+    ###############################################################################
+    #--------------------------------
+    #--- CENTRALIZED INPUT (CenIn)
+    #--------------------------------
+    #-- Test if the input file *mmg3d is read properly
+    SET(lsRefReadFile ".mmg3d OPENED")
+    foreach (NP 1 4)
+      add_test( NAME lsRef-Read-CenIn-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh -v 5 -nomove -noinsert -noswap -niter 1
+        -out ${CI_DIR_RESULTS}/lsRef-Read-CenIn-${NP}.o.mesh)
+
+        set_property(TEST lsRef-Read-CenIn-${NP}
+          PROPERTY PASS_REGULAR_EXPRESSION "${lsRefReadFile}")
+    endforeach()
+
+    #-- Test if tests with input file *mmg3d run correctly without errors WHITOUT LS
+    foreach (NP 1 2 4)
+      add_test( NAME lsRef-Run-CenIn-CenOut-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh -v 5
+        -out ${CI_DIR_RESULTS}/lsRef-Run-CenIn-CenOut-${NP}.o.mesh)
+
+      add_test( NAME lsRef-Run-CenIn-DisOut-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/LevelSet/1p_centralized/3D-cube.mesh -v 5 -distributed-output
+        -out ${CI_DIR_RESULTS}/lsRef-Run-CenIn-DisOut-${NP}.o.mesh)
+    endforeach()
+
+    #-- Test if tests with input file *mmg3d run correctly without errors WITH LS
+    # TODO once LS implemented
+
+    #--------------------------------
+    #--- DISTRIBUTED INPUT (DisIn)
+    #--------------------------------
+    #-- Test if the input file *mmg3d is read properly
+    add_test( NAME lsRef-Read-DisIn-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/2p_toygeom/cube-distributed-faces-mat-edges.mesh -v 5 -nomove -noinsert -noswap -niter 1
+      -out ${CI_DIR_RESULTS}/locParam-Read-DisIn-2.o.mesh)
+
+    set_property(TEST lsRef-Read-DisIn-2
+      PROPERTY PASS_REGULAR_EXPRESSION "${lsRefReadFile}")
+
+    #-- Test if tests with input file *mmg3d run correctly without errors WHITOUT LS
+    add_test( NAME lsRef-Run-DisIn-DisOut-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/2p_toygeom/cube-distributed-faces-mat-edges.mesh -v 5
+      -out ${CI_DIR_RESULTS}/lsRef-Run-DisIn-DisOut-2.o.mesh)
+
+    add_test( NAME lsRef-Run-DisIn-CenOut-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/2p_toygeom/cube-distributed-faces-mat-edges.mesh -v 5 -centralized-output
+      -out ${CI_DIR_RESULTS}/lsRef-Run-DisIn-CenOut-2.o.mesh)
+
+    #-- Test if tests with input file *mmg3d run correctly without errors WITH LS
+    # TODO once LS implemented
 
     ###############################################################################
     #####
@@ -568,6 +629,63 @@ IF( BUILD_TESTING )
         TEST hdf5-CenIn-DisOutHdf5-4
         PROPERTY PASS_REGULAR_EXPRESSION "${expr}")
     ENDIF ( )
+
+    ###############################################################################
+    #####
+    #####        Test with local parameters input file *mmg3d 'parameters'
+    #####
+    ###############################################################################
+    #--------------------------------
+    #--- CENTRALIZED INPUT (CenIn)
+    #--------------------------------
+    #-- Test if the input file *mmg3d is read properly
+    SET(locParamReadFile ".mmg3d OPENED")
+    foreach (NP 1 4)
+      add_test( NAME locParam-Read-CenIn-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/HausdLoc_2Spheres/centralized/2spheres.mesh -v 5 -nomove -noinsert -noswap -niter 1
+        -out ${CI_DIR_RESULTS}/locParam-Read-CenIn-${NP}.o.mesh)
+
+        set_property(TEST locParam-Read-CenIn-${NP}
+          PROPERTY PASS_REGULAR_EXPRESSION "${locParamReadFile}")
+    endforeach()
+
+    #-- Test if tests with input file *mmg3d run correctly without errors
+    foreach (NP 1 2 4)
+      add_test( NAME locParam-Run-CenIn-CenOut-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/HausdLoc_2Spheres/centralized/2spheres.mesh -v 5
+        -out ${CI_DIR_RESULTS}/locParam-Run-CenIn-CenOut-${NP}.o.mesh)
+
+      add_test( NAME locParam-Run-CenIn-DisOut-${NP}
+        COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} ${NP} $<TARGET_FILE:${PROJECT_NAME}>
+        ${CI_DIR}/HausdLoc_2Spheres/centralized/2spheres.mesh -v 5 -distributed-output
+        -out ${CI_DIR_RESULTS}/locParam-Run-CenIn-DisOut-${NP}.o.mesh)
+    endforeach()
+
+
+    #--------------------------------
+    #--- DISTRIBUTED INPUT (DisIn)
+    #--------------------------------
+    #-- Test if the input file *mmg3d is read properly
+    add_test( NAME locParam-Read-DisIn-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/HausdLoc_2Spheres/centralized/2spheres.mesh -v 5 -nomove -noinsert -noswap -niter 1
+      -out ${CI_DIR_RESULTS}/locParam-Read-DisIn-2.o.mesh)
+
+    set_property(TEST locParam-Read-DisIn-2
+      PROPERTY PASS_REGULAR_EXPRESSION "${locParamReadFile}")
+
+    #-- Test if tests with input file *mmg3d run correctly without errors
+    add_test( NAME locParam-Run-DisIn-DisOut-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/HausdLoc_2Spheres/centralized/2spheres.mesh -v 5
+      -out ${CI_DIR_RESULTS}/locParam-Run-DisIn-DisOut-2.o.mesh)
+
+    add_test( NAME locParam-Run-DisIn-CenOut-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/HausdLoc_2Spheres/centralized/2spheres.mesh -v 5 -centralized-output
+      -out ${CI_DIR_RESULTS}/locParam-Run-DisIn-CenOut-2.o.mesh)
 
   ENDIF()
 

--- a/src/mergemesh_pmmg.c
+++ b/src/mergemesh_pmmg.c
@@ -1518,7 +1518,7 @@ int PMMG_mergeParmesh_rcvParMeshes ( PMMG_pParMesh parmesh,PMMG_pGrp rcv_grps,
   /** Recover mesh infos */
   grp_1 = &rcv_grps[0];
   assert ( grp_1->mesh );
-  memcpy ( &mesh->info,&grp_1->mesh->info,sizeof(MMG5_Info) );
+  if ( !PMMG_copy_mmgInfo ( &grp_1->mesh->info,&mesh->info ) ) return 0;
 
   /** Recover mesh name */
 

--- a/src/mpipack_pmmg.c
+++ b/src/mpipack_pmmg.c
@@ -211,6 +211,10 @@ int PMMG_mpisizeof_infos ( MMG5_Info *info ) {
     idx += info->nmat*sizeof(int); //  mat->ref
     idx += info->nmat*sizeof(int); //  mat->rin
     idx += info->nmat*sizeof(int); //  mat->rex
+    assert( info->invmat.lookup);
+    idx += sizeof(int); // invmat->offset
+    idx += sizeof(int); // invmat->size
+    idx += info->invmat.size*sizeof(int); // invmat->lookup
   }
 
   /* local parameters */
@@ -790,6 +794,12 @@ void PMMG_mpipack_infos ( MMG5_Info *info,char **buffer ) {
       *( (int *) tmp)  = info->mat[k].ref; tmp += sizeof(int);
       *( (int *) tmp)  = info->mat[k].rin; tmp += sizeof(int);
       *( (int *) tmp)  = info->mat[k].rex; tmp += sizeof(int);
+    }
+    assert( info->invmat.lookup);
+    *( (int *) tmp) = info->invmat.offset; tmp += sizeof(int);
+    *( (int *) tmp) = info->invmat.size;   tmp += sizeof(int);
+    for ( k=0; k<info->invmat.size; ++k ) {
+      *( (int *) tmp) = info->invmat.lookup[k]; tmp += sizeof(int);
     }
   }
 

--- a/src/mpiunpack_pmmg.c
+++ b/src/mpiunpack_pmmg.c
@@ -519,6 +519,19 @@ void PMMG_mpiunpack_infos ( MMG5_Info *info,char **buffer,int *ier,int ier_mesh 
         *buffer += sizeof(int8_t);
         *buffer += 3*sizeof(int);
       }
+
+      info->invmat.offset  = *( (int *) *buffer); *buffer += sizeof(int);
+      info->invmat.size    = *( (int *) *buffer); *buffer += sizeof(int);
+      MMG5_SAFE_CALLOC(info->invmat.lookup,info->invmat.size,int, *ier = 0);
+      if ( *ier ) {
+        for ( k=0; k<info->invmat.size; ++k ) {
+          info->invmat.lookup[k] = *( (int *) *buffer);
+          *buffer += sizeof(int);
+        }
+      }
+      else {
+        *buffer += info->invmat.size*sizeof(int);
+      }
     }
 
     /* local parameters */
@@ -554,10 +567,14 @@ void PMMG_mpiunpack_infos ( MMG5_Info *info,char **buffer,int *ier,int ier_mesh 
     *buffer += 7*sizeof(uint8_t);
 
     if ( nmat ) {
+      /* mat */
       *buffer += nmat*sizeof(int8_t);
       *buffer += nmat*sizeof(int);
       *buffer += nmat*sizeof(int);
       *buffer += nmat*sizeof(int);
+      /* invmat */
+      *buffer += 2*sizeof(int);
+      *buffer += info->invmat.size*sizeof(int); // ????
     }
 
     /* local parameters */

--- a/src/mpiunpack_pmmg.c
+++ b/src/mpiunpack_pmmg.c
@@ -459,7 +459,7 @@ int PMMG_copy_filenames ( PMMG_pParMesh parmesh,PMMG_pGrp grp,int *ier,int ier_m
  */
 static
 void PMMG_mpiunpack_infos ( MMG5_Info *info,char **buffer,int *ier,int ier_mesh ) {
-  int   k,nmat,npar;
+  int   k,nmat,npar,invsize;
 
   if ( ier_mesh ) {
     /** Mesh infos */
@@ -573,8 +573,9 @@ void PMMG_mpiunpack_infos ( MMG5_Info *info,char **buffer,int *ier,int ier_mesh 
       *buffer += nmat*sizeof(int);
       *buffer += nmat*sizeof(int);
       /* invmat */
-      *buffer += 2*sizeof(int);
-      *buffer += info->invmat.size*sizeof(int); // ????
+      *buffer += sizeof(int);
+      invsize = *( (int *) *buffer); *buffer += sizeof(int);
+      *buffer += invsize*sizeof(int);
     }
 
     /* local parameters */

--- a/src/tools_pmmg.c
+++ b/src/tools_pmmg.c
@@ -111,6 +111,8 @@ const char* PMMG_Get_pmmgArgName(int typArg)
 int PMMG_copy_mmgInfo ( MMG5_Info *info, MMG5_Info *info_cpy ) {
   MMG5_pMat mat_tmp;
   MMG5_pPar par_tmp;
+  int       *lookup_tmp;
+  int i;
 
   // assert to remove (we may authorize to have mat and par already allocated )
   assert ( (!info_cpy->mat) && (!info_cpy->par) );
@@ -123,6 +125,22 @@ int PMMG_copy_mmgInfo ( MMG5_Info *info, MMG5_Info *info_cpy ) {
   }
   if ( mat_tmp ) {
     *mat_tmp = *info->mat;
+    for ( i=0; i<info->nmat; ++i ) {
+      mat_tmp[i]=info->mat[i];
+    }
+  }
+
+  if ( info->nmat && (!info_cpy->invmat.lookup) ) {
+    MMG5_SAFE_CALLOC(lookup_tmp,info->invmat.size,int,return 0);
+  }
+  else {
+    lookup_tmp = info_cpy->invmat.lookup;
+  }
+  if ( lookup_tmp ) {
+    *lookup_tmp = *info->invmat.lookup;
+    for ( i=0; i<info->invmat.size; ++i ) {
+      lookup_tmp[i]=info->invmat.lookup[i];
+    }
   }
 
   /* local parameters */
@@ -134,12 +152,16 @@ int PMMG_copy_mmgInfo ( MMG5_Info *info, MMG5_Info *info_cpy ) {
   }
   if ( par_tmp ) {
     *par_tmp = *info->par;
+    for ( i=0; i<info->npar; ++i ) {
+      par_tmp[i]=info->par[i];
+    }
   }
 
   *info_cpy = *info;
 
   info_cpy->mat = mat_tmp;
   info_cpy->par = par_tmp;
+  info_cpy->invmat.lookup = lookup_tmp;
 
   return 1;
 }


### PR DESCRIPTION
1. Replace `memcopy` by `PMMG_copy_mmgInfo` function to copy mesh information when merge the mesh in `PMMG_mergeParmesh_rcvParMeshes`. `memcopy` was copying the pointer address only and was leading to double free error.
2. Modify `PMMG_copy_mmgInfo` to now update correctly the copy of `mesh->info.mat`, `mesh->info.invmat.lookup` and `mesh->info.par` arrays when we have a `*mmg3d` input file (local parameters or LS multimat references).
3. Modify `PMMG_mpisizeof_filenames`, `PMMG_mpipack_infos` and `PMMG_mpiunpack_infos` to take into account `mesh->info.invmat` data correctly as the structure `MMG5_InvMat` was added to mmg after the initial creation of this function in ParMmg.
4. Add ci tests to ensure the input file `*mmg3d` is read correctly for centralized/distributed input and centralized/distributed output + update gitlab tag to point towards the latest up-to-date `testparmmg` commit.