### PR TITLE
Modify type of rtorecv and rtosend variables

### DIFF
--- a/src/communicators_pmmg.c
+++ b/src/communicators_pmmg.c
@@ -89,11 +89,11 @@ void PMMG_parmesh_ext_comm_free( PMMG_pParMesh parmesh,PMMG_pExt_comm listcomm,
     }
     if ( NULL != comm->rtosend ) {
       assert ( comm->nitem != 0 && "incorrect parameters in external communicator" );
-      PMMG_DEL_MEM(parmesh,comm->rtosend,int,"ext comm rtosend array");
+      PMMG_DEL_MEM(parmesh,comm->rtosend,double,"ext comm rtosend array");
     }
     if ( NULL != comm->rtorecv ) {
       assert ( comm->nitem != 0 && "incorrect parameters in external communicator" );
-      PMMG_DEL_MEM(parmesh,comm->rtorecv,int,"ext comm rtorecv array");
+      PMMG_DEL_MEM(parmesh,comm->rtorecv,double,"ext comm rtorecv array");
     }
   }
 }

--- a/src/zaldy_pmmg.c
+++ b/src/zaldy_pmmg.c
@@ -659,7 +659,7 @@ int PMMG_resize_extCommArray ( PMMG_pParMesh parmesh,PMMG_pExt_comm *ext_comm,
       PMMG_DEL_MEM ( parmesh,(*ext_comm+k)->rtosend, double,"rtosend" );
 
     if ( (*ext_comm+k)->rtorecv )
-      PMMG_DEL_MEM ( parmesh,(*ext_comm+k)->rtorecv,int,"rtorecv" );
+      PMMG_DEL_MEM ( parmesh,(*ext_comm+k)->rtorecv,double,"rtorecv" );
 
   }
 


### PR DESCRIPTION
Change type of `rtorecv` and `rtosend` variables in `PMMG_resize_extCommArray` and `PMMG_parmesh_ext_comm_free` functions. 
Type was `int` while it should have been `double`.