### PR TITLE
Add -f option in the help of ParMmg

### DIFF
--- a/src/libparmmg_tools.c
+++ b/src/libparmmg_tools.c
@@ -108,6 +108,8 @@ int PMMG_usage( PMMG_pParMesh parmesh, char * const prog )
     fprintf(stdout,"-sol   file  load level-set, displacement or metric file\n");
     fprintf(stdout,"-met   file  load metric file\n");
     fprintf(stdout,"-field file  load sol field to interpolate from init onto final mesh\n");
+    fprintf(stdout,"-f     file  load parameter file\n");
+
     fprintf(stdout,"-noout       do not write output triangulation\n");
     fprintf(stdout,"-centralized-output centralized output (Medit format only)\n");
     fprintf(stdout,"-distributed-output distributed output (Medit format only)\n");


### PR DESCRIPTION
In the help of ParMmg, add that it exists the option `-f` to specify the name of the file `*mmg3d` for multimat or local parameters.