### PR TITLE
API_DISTRIB_FACES prioritized over API_DISTRIB_NODES

### DIFF
--- a/src/inout_pmmg.c
+++ b/src/inout_pmmg.c
@@ -255,6 +255,7 @@ int PMMG_loadCommunicators( PMMG_pParMesh parmesh,const char *filename ) {
         MMG_FSCANF(inm,"%d",&ncomm);
         pos = ftell(inm);
         if (API_mode == PMMG_UNSET) {
+          /** if both parallel nodes and parallel faces are provided, use faces to build communicators */
           API_mode = PMMG_APIDISTRIB_nodes;
         }
         break;

--- a/src/inout_pmmg.c
+++ b/src/inout_pmmg.c
@@ -254,7 +254,9 @@ int PMMG_loadCommunicators( PMMG_pParMesh parmesh,const char *filename ) {
       } else if(!strncmp(chaine,"ParallelVertexCommunicators",strlen("ParallelVertexCommunicators"))) {
         MMG_FSCANF(inm,"%d",&ncomm);
         pos = ftell(inm);
-        API_mode = PMMG_APIDISTRIB_nodes;
+        if (API_mode == PMMG_UNSET) {
+          API_mode = PMMG_APIDISTRIB_nodes;
+        }
         break;
       }
     }
@@ -292,7 +294,9 @@ int PMMG_loadCommunicators( PMMG_pParMesh parmesh,const char *filename ) {
         MMG_FREAD(&ncomm,MMG5_SW,1,inm);
         if(iswp) ncomm=MMG5_swapbin(ncomm);
         pos = ftell(inm);
-        API_mode = PMMG_APIDISTRIB_nodes;
+        if (API_mode == PMMG_UNSET) {
+          API_mode = PMMG_APIDISTRIB_nodes;
+        }
         rewind(inm);
         fseek(inm,bpos,SEEK_SET);
         continue;


### PR DESCRIPTION
If both parallel nodes and parallel faces are provided, only parallel faces are kept for building communicators, regardless of order of data in input files.