### PR TITLE
Diagnose gatherv overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,8 @@ IF ( DOWNLOAD_MMG )
   OPTION ( USE_POINTMAP "Use map for point tracking" ON )
 
   EXTERNALPROJECT_ADD ( Mmg
-    GIT_REPOSITORY https://github.com/MmgTools/mmg.git
-    GIT_TAG 3a5e3abc38f7f100a481bcebe8aa23e105d7c381
+    GIT_REPOSITORY https://github.com/mpotse/mmg.git
+    GIT_TAG 0c583b2ecfbdbf76e4b98b82458e5f1cffbcfebf
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
     CMAKE_ARGS ${MMG_ARGS} -DUSE_ELAS=OFF ${COMPILER_CFG} ${FLAGS_CFG}
     ${SCOTCH_CFG} ${VTK_CFG} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,8 @@ IF ( DOWNLOAD_MMG )
   OPTION ( USE_POINTMAP "Use map for point tracking" ON )
 
   EXTERNALPROJECT_ADD ( Mmg
-    GIT_REPOSITORY https://github.com/mpotse/mmg.git
-    GIT_TAG 0c583b2ecfbdbf76e4b98b82458e5f1cffbcfebf
+    GIT_REPOSITORY https://github.com/MmgTools/mmg.git
+    GIT_TAG 3a5e3abc38f7f100a481bcebe8aa23e105d7c381
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
     CMAKE_ARGS ${MMG_ARGS} -DUSE_ELAS=OFF ${COMPILER_CFG} ${FLAGS_CFG}
     ${SCOTCH_CFG} ${VTK_CFG} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/src/parmmg.h
+++ b/src/parmmg.h
@@ -289,12 +289,14 @@ static const int PMMG_MVIFCS_NLAYERS = 2;
 
 
 #define ERROR_AT(msg1,msg2)                                          \
-  fprintf( stderr, msg1 msg2 " function: %s, file: %s, line: %d \n", \
-           __func__, __FILE__, __LINE__ )
+  fprintf( stderr, "%s %s function: %s, file: %s, line: %d \n", \
+           msg1, msg2, __func__, __FILE__, __LINE__ )
 
 #define MEM_CHK_AVAIL(mesh,bytes,msg) do {                            \
   if ( (mesh)->memCur + (bytes) > (mesh)->memMax ) {                  \
-    ERROR_AT(msg," Exceeded max memory allowed: ");      \
+    char diag[1024];                                                  \
+    snprintf(diag, 1024, " Allocation of %ld bytes exceeds max %ld: ", bytes, (mesh)->memMax); \
+    ERROR_AT(msg, diag);                                              \
     stat = PMMG_FAILURE;                                              \
   } else if ( (mesh)->memCur + (bytes) < 0  ) {                       \
     ERROR_AT(msg," Tried to free more mem than allocated: " );        \


### PR DESCRIPTION
The displacements argument to MPI_Gatherv() in PMMG_gather_parmesh() overflows when the combined packed mesh size exceeds 2^31. This commit does not solve the problem but it produces the right error message and an MPI_Abort() before an allocation error would occur. It also changes MEM_CHK_AVAIL to show the allocation size when an allocation fails, to make this kind of situation easier to diagnose.

Btw it looks like the size limit of ParMmg is actually smaller than that of mmg3d compiled with 32-bit indices; I encountered this problem with an input that takes 1.6GB storage while with mmg3d I have successfully treated a mesh that took 6.3GB storage. Also in terms of vertices and tetrahedra that mesh was much larger.

Of all possible solutions for this problem, I think the best would be to replace the gather operation by send/receive pairs. This would avoid the allocation of a buffer for the whole (packed) mesh.
