### PR TITLE
Update gfortran version after modification of Macos-12 runner.

### DIFF
--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -96,7 +96,7 @@ jobs:
           # gfortran compiler and scotch makefile depends on the os
           if [ "$RUNNER_OS" == "macOS" ]; then
              echo "SCOTCH_MAKE=Make.inc/Makefile.inc.i686_mac_darwin10" >> "$GITHUB_ENV"
-             echo "FORT_FLG=\"-DCMAKE_Fortran_COMPILER=gfortran-11\"" >> "$GITHUB_ENV"
+             echo "FORT_FLG=\"-DCMAKE_Fortran_COMPILER=gfortran-14\"" >> "$GITHUB_ENV"
              # Exclude test cases that fail on OSX due to surface model issue in Mmg.
              echo "EXCLUDE_TESTS=\"DistribSurf-A319\""  >> "$GITHUB_ENV"
 


### PR DESCRIPTION
gfortran-11 compiler is not installed anymore on MacOS-12 runner of github -> replace it by gfortran-14   