### PR TITLE
Disable value snapping (implementation in progress)

### DIFF
--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -455,8 +455,10 @@ IF( BUILD_TESTING )
       -ls 0.0
       -sol ${CI_DIR}/LevelSet/5p_cubegeom/3D-cube-ls.sol
       -out ${CI_DIR_RESULTS}/overlap-create.o.mesh)
+
     set_property(TEST overlap-create
-        PROPERTY PASS_REGULAR_EXPRESSION "${overlapCreation}")
+        PROPERTY PASS_REGULAR_EXPRESSION "${overlapCreation}"
+      )
 
     # Test if overlap is deleted
     set(overlapDelete " Delete Overlap")
@@ -551,6 +553,23 @@ IF( BUILD_TESTING )
       -out ${CI_DIR_RESULTS}/overlap-check-delete-met.o.mesh)
     set_property(TEST overlap-check-delete-met
       PROPERTY PASS_REGULAR_EXPRESSION "${overlapCheckDelete}")
+
+
+    # Temporary while snapval implementation is in progress and enabled only
+    # when the PMMG_SNAPVAL environment variable is defined
+    set_tests_properties(
+      overlap-check-P0
+      overlap-check-P0-met
+      overlap-check-P0P1
+      overlap-check-P0P2
+      overlap-check-P0P3
+      overlap-check-P0P4
+      overlap-check-delete
+      overlap-check-delete-met
+      overlap-create
+      overlap-delete
+      PROPERTIES ENVIRONMENT "PMMG_SNAPVAL=1"
+    )
 
     ###############################################################################
     #####

--- a/src/ls_pmmg.c
+++ b/src/ls_pmmg.c
@@ -1895,22 +1895,28 @@ int PMMG_ls(PMMG_pParMesh parmesh) {
     MPI_Abort(parmesh->comm,PMMG_TMPFAILURE);
   }
 
-  if ( !PMMG_create_overlap(parmesh,parmesh->info.read_comm) ) {
-    /* To avoid deadlocks in snpval_ls */
-    MPI_Abort(parmesh->comm,PMMG_TMPFAILURE);
-  }
+  /* Implementation in progress: call this part of code only when the
+   * PMMG_SNAPVAL environment variable is enabled */
+  const char* dev_snap = getenv("PMMG_SNAPVAL");
 
-  /** \todo TODO :: Snap values of level set function if needed */
-  if ( !PMMG_snpval_ls(parmesh,parmesh->info.read_comm) ) {
-    fprintf(stderr,"\n  ## Problem with implicit function. Exit program.\n");
-    /* To avoid deadlocks in parbdyTria */
-    ier = 0;
-  }
+  if ( dev_snap ) {
+    if ( !PMMG_create_overlap(parmesh,parmesh->info.read_comm) ) {
+      /* To avoid deadlocks in snpval_ls */
+      MPI_Abort(parmesh->comm,PMMG_TMPFAILURE);
+    }
 
-  /* Delete overlap */
-  if ( !PMMG_delete_overlap(parmesh,parmesh->info.read_comm) ) {
-    fprintf(stderr,"\n  ## Impossible to delete overlap. Exit program.\n");
-    ier = 0;
+    /** \todo TODO :: Snap values of level set function if needed */
+    if ( !PMMG_snpval_ls(parmesh,parmesh->info.read_comm) ) {
+      fprintf(stderr,"\n  ## Problem with implicit function. Exit program.\n");
+      /* To avoid deadlocks in parbdyTria */
+      ier = 0;
+    }
+
+    /* Delete overlap */
+    if ( !PMMG_delete_overlap(parmesh,parmesh->info.read_comm) ) {
+      fprintf(stderr,"\n  ## Impossible to delete overlap. Exit program.\n");
+      ier = 0;
+    }
   }
 
   /* Create table of adjacency for tetra */


### PR DESCRIPTION
Enable value snapping in distributed ls discretization mode only when `PMMG_SNAPVAL`environment variable is defined (implementation of the distributed value snapping is in progress).