### PR TITLE
Feature/ls partitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ To get and build ParMmg, you will need:
 
   If you don't have internet access and/or want to use your own installation of
   Mmg (resp. Metis), you can disable the automatic download of Mmg setting the
-  `DOWNLOAD_MMG` (resp. `DOWNLOAD_METIS`) CMake variable to `OFF`. In this case,
-  you can help CMake to find Mmg (resp. Metis) by specifying the source
-  directory of Mmg in the `MMG_DIR` variable and the build directory of Mmg in
-  the `MMG_BUILDDIR` variable (resp. the installation directory of Metis in the
-  `METIS_DIR` variable).
+  `DOWNLOAD_MMG` (resp. `DOWNLOAD_METIS`) CMake variable to `OFF`. In this case:
+
+  - Mmg has to be built with the private header installation enabled (turn `ON` the ` MMG_INSTALL_PRIVATE_HEADERS` CMake variable in Mmg at cmake configuration step);
+  - you can help CMake to find Mmg by specifying the installation
+  directory of Mmg in the `MMG_DIR` variable;
+  - you can help CMake to find Metis by specifying the installation directory of Metis in the
+  `METIS_DIR` variable.
   
   Example:
   ```Shell

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -365,6 +365,114 @@ IF( BUILD_TESTING )
 
     ###############################################################################
     #####
+    #####        Tests pure-partitioning option
+    #####
+    ###############################################################################
+    add_test( NAME PurePartitioning-CenIn-DisOut-withMetAndFields
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Interpolation/coarse.meshb
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-metAndFields-4-out.mesh
+      -field ${CI_DIR}/Interpolation/sol-fields-coarse.sol
+      -sol field3_iso-coarse.sol
+      -pure-partitioning
+      -distributed-output )
+
+    add_test( NAME PurePartitioning-CenIn-CenOut-withMetAndFields
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Interpolation/coarse.meshb
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-CenOut-metAndFields-4-out.mesh
+      -field ${CI_DIR}/Interpolation/sol-fields-coarse.sol
+      -sol field3_iso-coarse.sol
+      -pure-partitioning
+      -centralized-output )
+
+    add_test( NAME PurePartitioning-CenIn-CenOut
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Interpolation/coarse.meshb
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-CenOut-4-out.mesh
+      -pure-partitioning
+      -centralized-output )
+
+    add_test( NAME PurePartitioning-CenIn-DisOut
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Interpolation/coarse.meshb
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-4-out.mesh
+      -pure-partitioning
+      -distributed-output )
+
+    add_test( NAME PurePartitioning-CenIn-DisOut-withMet
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Interpolation/coarse.meshb
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-met-4-out.mesh
+      -sol field3_iso-coarse.sol
+      -pure-partitioning
+      -distributed-output )
+
+    add_test( NAME PurePartitioning-CenIn-CenOut-withMet
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Interpolation/coarse.meshb
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-CenOut-met-4-out.mesh
+      -sol field3_iso-coarse.sol
+      -pure-partitioning
+      -centralized-output )
+
+   add_test( NAME PurePartitioning-CenIn-h5-withMetAndFields
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/Interpolation/coarse.meshb
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-h5-metAndFields-4-out.h5
+      -field ${CI_DIR}/Interpolation/sol-fields-coarse.sol
+      -sol field3_iso-coarse.sol
+      -pure-partitioning )
+
+    add_test( NAME PurePartitioning-CenIn-DisOut-withMetAndLs-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube.mesh
+      -ls
+      -pure-partitioning
+      -sol ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-ls.sol
+      -met ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-metric.sol
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-withMetAndLs-2.o.mesh)
+
+   add_test( NAME PurePartitioning-CenIn-h5-withMetAndLs-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube.mesh
+      -ls
+      -pure-partitioning
+      -sol ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-ls.sol
+      -met ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-metric.sol
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-withMetAndLs-2.o.h5)
+
+    add_test( NAME PurePartitioning-CenIn-DisOut-withLs-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube.mesh
+      -ls
+      -pure-partitioning
+      -sol ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-ls.sol
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-withLs-2.o.mesh)
+
+   add_test( NAME PurePartitioning-CenIn-h5-withLs-2
+      COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:${PROJECT_NAME}>
+      ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube.mesh
+      -ls
+      -pure-partitioning
+      -sol ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-ls.sol
+      -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-withLs-2.o.h5)
+
+
+    IF ( (NOT HDF5_FOUND) OR USE_HDF5 MATCHES OFF )
+      SET(expr "HDF5 library not found")
+      SET_PROPERTY(
+        TEST
+        PurePartitioning-CenIn-h5-withMetAndFields
+        PurePartitioning-CenIn-h5-withMetAndLs-2
+        PurePartitioning-CenIn-h5-withLs-2
+        PROPERTY PASS_REGULAR_EXPRESSION "${expr}")
+    ENDIF ( )
+
+
+
+    ###############################################################################
+    #####
     #####        Tests distributed surface adaptation
     #####
     ###############################################################################
@@ -425,6 +533,7 @@ IF( BUILD_TESTING )
 
       ENDFOREACH()
     ENDFOREACH()
+
 
     # Test to verify the patch on update MG_REF tag.
     # This test fail if the tag MG_REF is not updated by PMMG_updateTagRef_node in PMMG_update_analys.

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -429,6 +429,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube.mesh
       -ls
       -pure-partitioning
+      -distributed-output
       -sol ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-ls.sol
       -met ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-metric.sol
       -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-withMetAndLs-2.o.mesh)
@@ -447,6 +448,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube.mesh
       -ls
       -pure-partitioning
+      -distributed-output
       -sol ${CI_DIR}/LevelSet/1p_cubegeom/3D-cube-ls.sol
       -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-withLs-2.o.mesh)
 

--- a/cmake/testing/pmmg_tests.cmake
+++ b/cmake/testing/pmmg_tests.cmake
@@ -340,7 +340,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/Interpolation/coarse.meshb
       -out ${CI_DIR_RESULTS}/InterpolationFields-withMet-withFields-4-out.mesh
       -field ${CI_DIR}/Interpolation/sol-fields-coarse.sol
-      -sol field3_iso-coarse.sol
+      -sol ${CI_DIR}/Interpolation/field3_iso-coarse.sol
       -mesh-size 60000 ${myargs} )
 
     add_test( NAME InterpolationFields-hsiz-4
@@ -373,7 +373,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/Interpolation/coarse.meshb
       -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-metAndFields-4-out.mesh
       -field ${CI_DIR}/Interpolation/sol-fields-coarse.sol
-      -sol field3_iso-coarse.sol
+      -sol ${CI_DIR}/Interpolation/field3_iso-coarse.sol
       -pure-partitioning
       -distributed-output )
 
@@ -382,7 +382,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/Interpolation/coarse.meshb
       -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-CenOut-metAndFields-4-out.mesh
       -field ${CI_DIR}/Interpolation/sol-fields-coarse.sol
-      -sol field3_iso-coarse.sol
+      -sol ${CI_DIR}/Interpolation/field3_iso-coarse.sol
       -pure-partitioning
       -centralized-output )
 
@@ -404,7 +404,7 @@ IF( BUILD_TESTING )
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/Interpolation/coarse.meshb
       -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-DisOut-met-4-out.mesh
-      -sol field3_iso-coarse.sol
+      -sol ${CI_DIR}/Interpolation/field3_iso-coarse.sol
       -pure-partitioning
       -distributed-output )
 
@@ -412,7 +412,7 @@ IF( BUILD_TESTING )
       COMMAND ${MPIEXEC} ${MPI_ARGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:${PROJECT_NAME}>
       ${CI_DIR}/Interpolation/coarse.meshb
       -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-CenOut-met-4-out.mesh
-      -sol field3_iso-coarse.sol
+      -sol ${CI_DIR}/Interpolation/field3_iso-coarse.sol
       -pure-partitioning
       -centralized-output )
 
@@ -421,7 +421,7 @@ IF( BUILD_TESTING )
       ${CI_DIR}/Interpolation/coarse.meshb
       -out ${CI_DIR_RESULTS}/PurePartitioning-CenIn-h5-metAndFields-4-out.h5
       -field ${CI_DIR}/Interpolation/sol-fields-coarse.sol
-      -sol field3_iso-coarse.sol
+      -sol ${CI_DIR}/Interpolation/field3_iso-coarse.sol
       -pure-partitioning )
 
     add_test( NAME PurePartitioning-CenIn-DisOut-withMetAndLs-2

--- a/src/API_functions_pmmg.c
+++ b/src/API_functions_pmmg.c
@@ -382,6 +382,77 @@ int PMMG_Set_outputSolsName(PMMG_pParMesh parmesh, const char* solout) {
   return ier;
 }
 
+int PMMG_Set_outputLsName(PMMG_pParMesh parmesh, const char* lsout) {
+  MMG5_pMesh mesh;
+  MMG5_pSol  ls;
+  int        k,ier,pathlen,baselen;
+  char      *basename,*path,*nopath;
+
+  /* If \a lsout is not provided we want to use the basename of the input ls
+   * name and the path of the output mesh name */
+  if ( parmesh->lsout ) {
+    PMMG_DEL_MEM(parmesh,parmesh->fieldout,char,"fieldout unalloc");
+  }
+
+  if ( (!lsout) || (!*lsout) ) {
+
+    if ( (!parmesh->meshout) || (!*parmesh->meshout) ) {
+      fprintf(stderr, "  ## Error: %s: please, provide an output mesh"
+              " name before calling this function without string.\n",
+              __func__);
+      return 0;
+    }
+
+    /* Get input field base name and remove .mesh extension */
+    if ( (!parmesh->lsin) || (!*parmesh->lsin) ) {
+      fprintf(stderr, "  ## Error: %s: please, provide an input field"
+              " name before calling this function without string.\n",
+              __func__);
+      return 0;
+    }
+
+    path   = MMG5_Get_path(parmesh->meshout);
+    nopath = MMG5_Get_basename(parmesh->lsin);
+    basename = MMG5_Remove_ext ( nopath,".sol" );
+
+    pathlen = baselen = 0;
+    if ( path ) pathlen = strlen(path)+1;
+    if ( basename ) baselen = strlen(basename);
+    PMMG_MALLOC(parmesh,parmesh->lsout,pathlen+baselen+1,char,"lsout",return 0);
+    if ( pathlen ) {
+      strncpy(parmesh->lsout,path,pathlen-1);
+      parmesh->lsout[pathlen-1] = MMG5_PATHSEP;
+    }
+    if ( baselen ) {
+      strncpy(parmesh->lsout+pathlen,basename,baselen);
+      parmesh->lsout[pathlen+baselen] = '\0';
+    }
+
+    if ( parmesh->lsout ) {
+      /* Add .o.sol extension */
+      PMMG_REALLOC(parmesh,parmesh->lsout,strlen(parmesh->lsout)+7,
+                   strlen(parmesh->lsout)+1,char,"lsout",return 0);
+      strncat ( parmesh->lsout,".o.sol",7 );
+    }
+
+    MMG5_SAFE_FREE ( path );
+    free ( nopath ); nopath = NULL;
+    MMG5_SAFE_FREE ( basename );
+  }
+  else {
+    PMMG_MALLOC(parmesh,parmesh->lsout,strlen(lsout)+1,char,"lsout",return 0);
+    strcpy(parmesh->lsout,lsout);
+  }
+
+  for ( k=0; k<parmesh->ngrp; ++k ) {
+    mesh = parmesh->listgrp[k].mesh;
+    ls   = parmesh->listgrp[k].ls;
+    ier  = MMG3D_Set_outputSolName(mesh,ls,parmesh->lsout);
+  }
+  return ier;
+}
+
+
 int PMMG_Set_outputMetName(PMMG_pParMesh parmesh, const char* metout) {
   MMG5_pMesh mesh;
   MMG5_pSol  met;
@@ -625,6 +696,11 @@ int PMMG_Set_iparameter(PMMG_pParMesh parmesh, int iparam,int val) {
 #endif
   case PMMG_IPARAM_debug :
     parmesh->ddebug = val;
+    break;
+
+  case PMMG_IPARAM_purePartitioning :
+
+    parmesh->info.pure_partitioning = val;
     break;
 
   case PMMG_IPARAM_distributedOutput :
@@ -2795,6 +2871,7 @@ int PMMG_Free_names(PMMG_pParMesh parmesh)
   PMMG_DEL_MEM ( parmesh, parmesh->metin,char,"metin" );
   PMMG_DEL_MEM ( parmesh, parmesh->metout,char,"metout" );
   PMMG_DEL_MEM ( parmesh, parmesh->lsin,char,"lsin" );
+  PMMG_DEL_MEM ( parmesh, parmesh->lsout,char,"lsout" );
   PMMG_DEL_MEM ( parmesh, parmesh->dispin,char,"dispin" );
   PMMG_DEL_MEM ( parmesh, parmesh->fieldin,char,"fieldin" );
   PMMG_DEL_MEM ( parmesh, parmesh->fieldout,char,"fieldout" );

--- a/src/API_functionsf_pmmg.c
+++ b/src/API_functionsf_pmmg.c
@@ -1357,6 +1357,44 @@ FORTRAN_NAME(PMMG_SAVEMET_DISTRIBUTED,pmmg_savemet_distributed,
 }
 
 /**
+ * See \ref PMMG_saveLs_centralized function in \ref libparmmg.h file.
+ */
+FORTRAN_NAME(PMMG_SAVELS_CENTRALIZED,pmmg_savels_centralized,
+             (PMMG_pParMesh *parmesh,char* filename, int *strlen,int* retval),
+             (parmesh,filename,strlen,retval)){
+  char *tmp = NULL;
+
+  MMG5_SAFE_MALLOC(tmp,(*strlen+1),char,);
+  strncpy(tmp,filename,*strlen);
+  tmp[*strlen] = '\0';
+
+  *retval = PMMG_saveLs_centralized(*parmesh,tmp);
+
+  MMG5_SAFE_FREE(tmp);
+
+  return;
+}
+
+/**
+ * See \ref PMMG_saveLs_distributed function in \ref libparmmg.h file.
+ */
+FORTRAN_NAME(PMMG_SAVELS_DISTRIBUTED,pmmg_savels_distributed,
+             (PMMG_pParMesh *parmesh,char* filename, int *strlen,int* retval),
+             (parmesh,filename,strlen,retval)){
+  char *tmp = NULL;
+
+  MMG5_SAFE_MALLOC(tmp,(*strlen+1),char,);
+  strncpy(tmp,filename,*strlen);
+  tmp[*strlen] = '\0';
+
+  *retval = PMMG_saveLs_distributed(*parmesh,tmp);
+
+  MMG5_SAFE_FREE(tmp);
+
+  return;
+}
+
+/**
  * See \ref PMMG_saveAllSols_centralized function in \ref libparmmg.h file.
  */
 FORTRAN_NAME(PMMG_SAVEALLSOLS_CENTRALIZED,pmmg_saveallsols_centralized,

--- a/src/libparmmg.c
+++ b/src/libparmmg.c
@@ -1820,6 +1820,9 @@ int PMMG_parmmg_centralized(PMMG_pParMesh parmesh) {
       return ierlib;
     }
   }
+  else {
+    ierlib = 0;
+  }
 
   ier = PMMG_parmmglib_post(parmesh);
   ierlib = MG_MAX ( ier, ierlib );

--- a/src/libparmmg.c
+++ b/src/libparmmg.c
@@ -181,24 +181,26 @@ int PMMG_preprocessMesh( PMMG_pParMesh parmesh )
     return PMMG_STRONGFAILURE;
   }
 
-  /* Discretization of the isovalue  */
-  if (mesh->info.iso) {
-    tim = 1;
-    chrono(ON,&(ctim[tim]));
-    if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
-      fprintf(stdout,"\n  -- PHASE 1a: ISOVALUE DISCRETIZATION     \n");
-    }
-    if ( !MMG3D_mmg3d2(mesh,ls,met) ) {
-      return PMMG_STRONGFAILURE;
-    }
-    /* Update mesh->npi and mesh->nei to be equal to mesh->np and mesh->ne, respectively */
-    mesh->npi = mesh->np;
-    mesh->nei = mesh->ne;
+  if ( !parmesh->info.pure_partitioning ) {
+    /* Discretization of the isovalue  */
+    if (mesh->info.iso) {
+      tim = 1;
+      chrono(ON,&(ctim[tim]));
+      if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
+        fprintf(stdout,"\n  -- PHASE 1a: ISOVALUE DISCRETIZATION     \n");
+      }
+      if ( !MMG3D_mmg3d2(mesh,ls,met) ) {
+        return PMMG_STRONGFAILURE;
+      }
+      /* Update mesh->npi and mesh->nei to be equal to mesh->np and mesh->ne, respectively */
+      mesh->npi = mesh->np;
+      mesh->nei = mesh->ne;
 
-    chrono(OFF,&(ctim[tim]));
-    printim(ctim[tim].gdif,stim);
-    if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
-      fprintf(stdout,"  -- PHASE 1a COMPLETED     %s\n",stim);
+      chrono(OFF,&(ctim[tim]));
+      printim(ctim[tim].gdif,stim);
+      if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
+        fprintf(stdout,"  -- PHASE 1a COMPLETED     %s\n",stim);
+      }
     }
   }
 
@@ -207,14 +209,17 @@ int PMMG_preprocessMesh( PMMG_pParMesh parmesh )
     return PMMG_STRONGFAILURE;
   }
 
-  /* Check if the LS has led to a non-manifold topology */
-  if ( mesh->info.iso && !MMG3D_chkmani(mesh) ) {
-    fprintf(stderr,"\n  ## LS discretization: non-manifold initial topology. Exit program.\n");
-    return PMMG_STRONGFAILURE;
-  }
-  else {
-    if ( parmesh->info.imprim > PMMG_VERB_VERSION && mesh->info.iso ) {
-      fprintf(stdout,"       LS discretization OK: no non-manifold topology.\n");
+  if ( !parmesh->info.pure_partitioning ) {
+
+    /* Check if the LS has led to a non-manifold topology */
+    if ( mesh->info.iso && !MMG3D_chkmani(mesh) ) {
+      fprintf(stderr,"\n  ## LS discretization: non-manifold initial topology. Exit program.\n");
+      return PMMG_STRONGFAILURE;
+    }
+    else {
+      if ( parmesh->info.imprim > PMMG_VERB_VERSION && mesh->info.iso ) {
+        fprintf(stdout,"       LS discretization OK: no non-manifold topology.\n");
+      }
     }
   }
 
@@ -395,34 +400,37 @@ int PMMG_preprocessMesh_distributed( PMMG_pParMesh parmesh )
   }
   MMG5_SAFE_FREE( permtria );
 
-  /** Discretization of the isovalue  */
-  if (mesh->info.iso) {
+  if ( !parmesh->info.pure_partitioning ) {
 
-    /* Destroy adja and adjat */
-    MMG5_DEL_MEM(mesh,mesh->adja);
-    MMG5_DEL_MEM(mesh,mesh->adjt);
+    /** Discretization of the isovalue  */
+    if (mesh->info.iso) {
 
-    tim = 1;
-    chrono(ON,&(ctim[tim]));
-    if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
-      fprintf(stdout,"\n  -- PHASE 1a: ISOVALUE DISCRETIZATION     \n");
-      fprintf(stdout,"  --    under development     \n");
-    }
-    if ( !PMMG_ls(parmesh) ) {
-      return PMMG_STRONGFAILURE;
-    }
+      /* Destroy adja and adjat */
+      MMG5_DEL_MEM(mesh,mesh->adja);
+      MMG5_DEL_MEM(mesh,mesh->adjt);
 
-    chrono(OFF,&(ctim[tim]));
-    printim(ctim[tim].gdif,stim);
-    if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
-      fprintf(stdout,"\n  -- PHASE 1a COMPLETED     %s\n",stim);
-    }
-
-    /** Mesh analysis Ib : After LS discretization
-     * Check triangles, create xtetras */
-    if ( parmesh->myrank < parmesh->info.npartin ) {
-      if ( !PMMG_analys_tria(parmesh,mesh,permtria) ) {
+      tim = 1;
+      chrono(ON,&(ctim[tim]));
+      if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
+        fprintf(stdout,"\n  -- PHASE 1a: ISOVALUE DISCRETIZATION     \n");
+        fprintf(stdout,"  --    under development     \n");
+      }
+      if ( !PMMG_ls(parmesh) ) {
         return PMMG_STRONGFAILURE;
+      }
+
+      chrono(OFF,&(ctim[tim]));
+      printim(ctim[tim].gdif,stim);
+      if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
+        fprintf(stdout,"\n  -- PHASE 1a COMPLETED     %s\n",stim);
+      }
+
+      /** Mesh analysis Ib : After LS discretization
+       * Check triangles, create xtetras */
+      if ( parmesh->myrank < parmesh->info.npartin ) {
+        if ( !PMMG_analys_tria(parmesh,mesh,permtria) ) {
+          return PMMG_STRONGFAILURE;
+        }
       }
     }
   }
@@ -1610,6 +1618,11 @@ int PMMG_parmmglib_post(PMMG_pParMesh parmesh) {
 
   iresult = 1;
 
+  if ( parmesh->niter == 0 || parmesh->info.pure_partitioning ) {
+    /* set parmesh->iter to allow saving of mesh communicators */
+    parmesh->iter = 0;
+  }
+
   switch ( parmesh->info.fmtout ) {
   case ( PMMG_UNSET ):
     /* No output */
@@ -1765,6 +1778,18 @@ int PMMG_parmmg_centralized(PMMG_pParMesh parmesh) {
     }
   }
 
+  /* I/O check: if an input ls name is provided but the output one is not,
+   compute automatically an output ls name. */
+  if ( parmesh->lsin &&  *parmesh->lsin ) {
+    ier = PMMG_Set_outputLsName(parmesh,NULL);
+    if ( !ier ) {
+      fprintf(stdout,"  ## Warning: %s: rank %d: an input field name is"
+              " provided without an output one.\n"
+              "            : the saving process may fail.\n",
+              __func__,parmesh->myrank);
+    }
+  }
+
   /* Distribute the mesh */
   ier = PMMG_distributeMesh_centralized_timers( parmesh, ctim );
   if( ier != PMMG_SUCCESS ) return ier;
@@ -1782,16 +1807,18 @@ int PMMG_parmmg_centralized(PMMG_pParMesh parmesh) {
              met->size < 6 ? "ISOTROPIC" : "ANISOTROPIC" );
   }
 
-  ier = PMMG_parmmglib1(parmesh);
-  MPI_Allreduce( &ier, &ierlib, 1, MPI_INT, MPI_MAX, parmesh->comm );
+  if ( !parmesh->info.pure_partitioning ) {
+    ier = PMMG_parmmglib1(parmesh);
+    MPI_Allreduce( &ier, &ierlib, 1, MPI_INT, MPI_MAX, parmesh->comm );
 
-  chrono(OFF,&(ctim[tim]));
-  printim(ctim[tim].gdif,stim);
-  if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
-    fprintf(stdout,"  -- PHASE 2 COMPLETED.     %s\n",stim);
-  }
-  if ( ierlib == PMMG_STRONGFAILURE ) {
-    return ierlib;
+    chrono(OFF,&(ctim[tim]));
+    printim(ctim[tim].gdif,stim);
+    if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
+      fprintf(stdout,"  -- PHASE 2 COMPLETED.     %s\n",stim);
+    }
+    if ( ierlib == PMMG_STRONGFAILURE ) {
+      return ierlib;
+    }
   }
 
   ier = PMMG_parmmglib_post(parmesh);
@@ -1895,6 +1922,14 @@ int PMMG_parmmg_distributed(PMMG_pParMesh parmesh) {
     return iresult;
   }
 
+  if ( parmesh->info.pure_partitioning ) {
+    if ( parmesh->myrank == parmesh->info.root ) {
+      fprintf(stderr,"\n  ## Error: %s: Pure repartitioning from distributed"
+              " input not implemented.\n",__func__);
+    }
+    return PMMG_STRONGFAILURE;
+  }
+
   /* I/O check: if the mesh was loaded with nprocs != npartin (for example from
      hdf5 file), call loadBalancing before the remeshing loop to make sure no
      proc has an empty mesh (nprocs > npartin) and the load is well balanced
@@ -1920,24 +1955,26 @@ int PMMG_parmmg_distributed(PMMG_pParMesh parmesh) {
     fprintf(stdout,"  -- PHASE 1 COMPLETED.     %s\n",stim);
   }
 
-  /** Remeshing */
-  tim = 3;
-  chrono(ON,&(ctim[tim]));
-  if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
-    fprintf( stdout,"\n  -- PHASE 2 : %s MESHING\n",
-            parmesh->listgrp[0].met->size < 6 ? "ISOTROPIC" : "ANISOTROPIC" );
-  }
+  if ( !parmesh->info.pure_partitioning ) {
+    /** Remeshing */
+    tim = 3;
+    chrono(ON,&(ctim[tim]));
+    if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
+      fprintf( stdout,"\n  -- PHASE 2 : %s MESHING\n",
+               parmesh->listgrp[0].met->size < 6 ? "ISOTROPIC" : "ANISOTROPIC" );
+    }
 
-  ier = PMMG_parmmglib1(parmesh);
-  MPI_Allreduce( &ier, &ierlib, 1, MPI_INT, MPI_MAX, parmesh->comm );
+    ier = PMMG_parmmglib1(parmesh);
+    MPI_Allreduce( &ier, &ierlib, 1, MPI_INT, MPI_MAX, parmesh->comm );
 
-  chrono(OFF,&(ctim[tim]));
-  printim(ctim[tim].gdif,stim);
-  if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
-    fprintf(stdout,"  -- PHASE 2 COMPLETED.     %s\n",stim);
-  }
-  if ( ierlib == PMMG_STRONGFAILURE ) {
-    return ierlib;
+    chrono(OFF,&(ctim[tim]));
+    printim(ctim[tim].gdif,stim);
+    if ( parmesh->info.imprim > PMMG_VERB_VERSION ) {
+      fprintf(stdout,"  -- PHASE 2 COMPLETED.     %s\n",stim);
+    }
+    if ( ierlib == PMMG_STRONGFAILURE ) {
+      return ierlib;
+    }
   }
 
   ier = PMMG_parmmglib_post(parmesh);

--- a/src/libparmmg.h
+++ b/src/libparmmg.h
@@ -70,6 +70,7 @@ enum PMMG_Param {
   PMMG_IPARAM_nomove,            /*!< [1/0], Avoid/allow point relocation */
   PMMG_IPARAM_nosurf,            /*!< [1/0], Avoid/allow surface modifications */
   PMMG_IPARAM_numberOfLocalParam,/*!< [n], Number of local parameters */
+  PMMG_IPARAM_purePartitioning, /*!< [0/1], Turn off/on pure mesh partitioning (no ls insertion, no remeshing) */
   PMMG_IPARAM_anisosize,         /*!< [1/0], Turn on/off anisotropic metric creation when no metric is provided */
   PMMG_IPARAM_octree,            /*!< [n], Specify the max number of points per octree cell (DELAUNAY) */
   PMMG_IPARAM_meshSize,          /*!< [n], Target mesh size of Mmg (advanced use) */
@@ -388,6 +389,24 @@ int  PMMG_Set_outputSolsName(PMMG_pParMesh parmesh, const char* solout);
  *
  */
 int  PMMG_Set_outputMetName(PMMG_pParMesh parmesh, const char* metout);
+
+/**
+ * \param parmesh pointer toward a parmesh structure.
+ * \param lsout name of the output level-set file.
+ * \return 0 if failed, 1 otherwise.
+ *
+ *  Set the name of output level-set file.
+ *
+ * \remark Fortran interface:
+ * >   SUBROUTINE PMMG_SET_OUTPUTLSNAME(parmesh,lsout,strlen,retval)\n
+ * >     MMG5_DATA_PTR_T, INTENT(INOUT) :: parmesh\n
+ * >     CHARACTER(LEN=*), INTENT(IN)   :: lsout\n
+ * >     INTEGER, INTENT(IN)            :: strlen\n
+ * >     INTEGER, INTENT(OUT)           :: retval\n
+ * >   END SUBROUTINE\n
+ *
+ */
+int  PMMG_Set_outputLsName(PMMG_pParMesh parmesh, const char* lsout);
 
 /**
  * \param parmesh pointer toward the parmesh structure.
@@ -2114,7 +2133,45 @@ int PMMG_usage( PMMG_pParMesh parmesh, char * const prog);
  * \param filename name of file.
  * \return 0 if failed, 1 otherwise.
  *
- * Write 1 or more than 1 solution in a file at medit format.
+ * Write level-set in a file at medit format.
+ *
+ * \remark Fortran interface:
+ * >   SUBROUTINE PMMG_SAVELS_CENTRALIZED(parmesh,filename,strlen,retval)\n
+ * >     MMG5_DATA_PTR_T, INTENT(INOUT) :: parmesh\n
+ * >     CHARACTER(LEN=*), INTENT(IN)   :: filename\n
+ * >     INTEGER, INTENT(IN)            :: strlen\n
+ * >     INTEGER, INTENT(OUT)           :: retval\n
+ * >   END SUBROUTINE\n
+ *
+ */
+  int PMMG_saveLs_centralized(PMMG_pParMesh parmesh, const char *filename);
+
+/**
+ * \param parmesh pointer toward the parmesh structure.
+ * \param filename name of file.
+ * \return 0 if failed, 1 otherwise.
+ *
+ * Write level-set in a file at medit format for a distributed
+ * mesh (insert rank index to filename).
+ *
+ * \remark Fortran interface:
+ * >   SUBROUTINE PMMG_SAVELS_DISTRIBUTED(parmesh,filename,strlen,retval)\n
+ * >     MMG5_DATA_PTR_T, INTENT(INOUT) :: parmesh\n
+ * >     CHARACTER(LEN=*), INTENT(IN)   :: filename\n
+ * >     INTEGER, INTENT(IN)            :: strlen\n
+ * >     INTEGER, INTENT(OUT)           :: retval\n
+ * >   END SUBROUTINE\n
+ *
+ */
+  int PMMG_saveLs_distributed(PMMG_pParMesh parmesh, const char *filename);
+
+
+/**
+ * \param parmesh pointer toward the parmesh structure.
+ * \param filename name of file.
+ * \return 0 if failed, 1 otherwise.
+ *
+ * Write 1 or more than 1 solution field in a file at medit format.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE PMMG_SAVEALLSOLS_CENTRALIZED(parmesh,filename,strlen,retval)\n
@@ -2132,7 +2189,7 @@ int PMMG_usage( PMMG_pParMesh parmesh, char * const prog);
  * \param filename name of file.
  * \return 0 if failed, 1 otherwise.
  *
- * Write 1 or more than 1 solution in a file at medit format for a distributed
+ * Write 1 or more than 1 solution field in a file at medit format for a distributed
  * mesh (insert rank index to filename).
  *
  * \remark Fortran interface:

--- a/src/libparmmgtypes.h
+++ b/src/libparmmgtypes.h
@@ -369,6 +369,7 @@ typedef struct {
   int setfem;  /*!< fem mesh (no elt with more than 1 bdy face */
   int mmg_imprim; /*!< 1 if the user has manually setted the mmg verbosity */
   int repartitioning; /*!< way to perform mesh repartitioning */
+  int pure_partitioning; /*!< enable/disable pure mesh partitioning mode  */
   int ifc_layers;  /*!< nb of layers for interface displacement */
   double grps_ratio;  /*!< allowed imbalance ratio between current and demanded groups size */
   int nobalancing; /*!< switch off final load balancing */
@@ -426,7 +427,7 @@ typedef struct {
   /* file names */
   char     *meshin,*meshout;
   char     *metin,*metout;
-  char     *lsin;
+  char     *lsin,*lsout;
   char     *dispin;
   char     *fieldin,*fieldout;
 

--- a/src/mergemesh_pmmg.c
+++ b/src/mergemesh_pmmg.c
@@ -1600,6 +1600,9 @@ int PMMG_mergeParmesh_rcvParMeshes ( PMMG_pParMesh parmesh,PMMG_pGrp rcv_grps,
     if ( parmesh->lsin ) {
       MMG3D_Set_inputSolName (mesh,ls, parmesh->lsin);
     }
+    if ( parmesh->lsout ) {
+      MMG3D_Set_outputSolName (mesh,ls, parmesh->lsout);
+    }
   }
   if ( disp ) {
     if ( parmesh->dispin ) {

--- a/src/mpiunpack_pmmg.c
+++ b/src/mpiunpack_pmmg.c
@@ -417,6 +417,11 @@ int PMMG_copy_filenames ( PMMG_pParMesh parmesh,PMMG_pGrp grp,int *ier,int ier_m
     if ( parmesh->lsin && *parmesh->lsin ) {
       if ( !MMG5_Set_inputSolName( mesh, ls, parmesh->lsin ) ) { *ier = 0; }
     }
+    if ( parmesh->lsout && *parmesh->lsout ) {
+      if ( !MMG5_Set_outputSolName( mesh, ls, parmesh->lsout ) ) {
+        *ier = 0;
+      }
+    }
   }
 
   if ( ier_disp && disp ) {

--- a/src/parmmg.c
+++ b/src/parmmg.c
@@ -470,6 +470,13 @@ check_mesh_loading:
       if ( ier &&  grp->field ) {
         ier = PMMG_saveAllSols_distributed(parmesh,parmesh->fieldout);
       }
+      if ( ier &&  grp->ls ) {
+        /* Warning: if the ls has the same name than the metric (default case
+         * when no input metric in ls mode), if the ls is not deallocated, the
+         * metric file is overwritten */
+        ier = PMMG_saveLs_distributed(parmesh,parmesh->lsout);
+      }
+
       MPI_Allreduce( &ier, &ierSave, 1, MPI_INT, MPI_MIN, parmesh->comm );
 
       break;
@@ -490,6 +497,14 @@ check_mesh_loading:
       if ( ierSave && grp->field ) {
         ierSave = PMMG_saveAllSols_centralized(parmesh,parmesh->fieldout);
       }
+
+      if ( ierSave && grp->ls ) {
+        /* Warning: if the ls has the same name than the metric (default case
+         * when no input metric in ls mode), if the ls is not deallocated, the
+         * metric file is overwritten */
+        ierSave = PMMG_saveLs_centralized(parmesh,parmesh->lsout);
+      }
+
       break;
     }
   }


### PR DESCRIPTION
Add the `-pure-partitioning`option to partition a centralized input and the associated data (level-set, metric or solution fields) without doing anything else (no ls insertion, no remeshing..).